### PR TITLE
feat: add version display in app title with commit hash

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,8 @@
 .PHONY: help setup build test clean run-web run-macos run-android web-worker db-gen analyze format install-hooks
 
+# Git commit hash for version display
+GIT_HASH := $(shell git rev-parse --short HEAD 2>/dev/null || echo "unknown")
+
 # Default target
 help:
 	@echo "Open Score - Development Makefile"
@@ -75,24 +78,24 @@ web-worker:
 # Build targets
 build-web: web-worker
 	@echo "🌐 Building for web (release)..."
-	flutter build web --release
+	flutter build web --release --dart-define=GIT_HASH=$(GIT_HASH)
 	@echo "Copying web worker files to build output..."
 	cp -f web/sqlite3.wasm web/drift_worker.js build/web/
 	@echo "✅ Web build complete: build/web/"
 
 build-macos:
 	@echo "🖥️  Building for macOS (release)..."
-	flutter build macos --release
+	flutter build macos --release --dart-define=GIT_HASH=$(GIT_HASH)
 	@echo "✅ macOS build complete"
 
 build-android:
 	@echo "🤖 Building for Android (release)..."
-	flutter build apk --release
+	flutter build apk --release --dart-define=GIT_HASH=$(GIT_HASH)
 	@echo "✅ Android APK: build/app/outputs/flutter-apk/app-release.apk"
 
 build-ios:
 	@echo "📱 Building for iOS (release)..."
-	flutter build ios --release --no-codesign
+	flutter build ios --release --no-codesign --dart-define=GIT_HASH=$(GIT_HASH)
 	@echo "✅ iOS build complete"
 
 build-all: build-web build-macos build-android
@@ -101,15 +104,15 @@ build-all: build-web build-macos build-android
 # Run targets
 run-web: web-worker
 	@echo "🌐 Running on Chrome..."
-	flutter run -d chrome
+	flutter run -d chrome --dart-define=GIT_HASH=$(GIT_HASH)
 
 run-macos:
 	@echo "🖥️  Running on macOS..."
-	flutter run -d macos
+	flutter run -d macos --dart-define=GIT_HASH=$(GIT_HASH)
 
 run-android:
 	@echo "🤖 Running on Android..."
-	flutter run -d android
+	flutter run -d android --dart-define=GIT_HASH=$(GIT_HASH)
 
 # Serve web build locally
 serve-web: build-web

--- a/lib/screens/library_screen.dart
+++ b/lib/screens/library_screen.dart
@@ -4,6 +4,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../models/database.dart';
 import '../services/database_service.dart';
 import '../services/pdf_service.dart';
+import '../services/version_service.dart';
 import '../widgets/pdf_card.dart';
 import 'pdf_viewer_screen.dart';
 
@@ -143,9 +144,27 @@ class _LibraryScreenState extends ConsumerState<LibraryScreen> {
   Widget build(BuildContext context) {
     final documentsAsync = ref.watch(documentsProvider);
 
+    final versionInfo = ref.watch(versionInfoProvider);
+
     return Scaffold(
       appBar: AppBar(
-        title: const Text('Open Score'),
+        title: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            const Text('Open Score'),
+            const SizedBox(width: 8),
+            versionInfo.when(
+              data: (info) => Text(
+                info.displayString,
+                style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                  color: Theme.of(context).colorScheme.onSurface.withAlpha(153),
+                ),
+              ),
+              loading: () => const SizedBox.shrink(),
+              error: (error, stack) => const SizedBox.shrink(),
+            ),
+          ],
+        ),
         actions: [
           IconButton(
             icon: Icon(_isGridView ? Icons.view_list : Icons.grid_view),

--- a/lib/services/version_service.dart
+++ b/lib/services/version_service.dart
@@ -1,0 +1,54 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:package_info_plus/package_info_plus.dart';
+
+/// Git commit hash, passed via --dart-define at build time
+const String _gitHash = String.fromEnvironment('GIT_HASH', defaultValue: 'dev');
+
+/// Version information for the app
+class VersionInfo {
+  final String version;
+  final String buildNumber;
+  final String gitHash;
+
+  const VersionInfo({
+    required this.version,
+    required this.buildNumber,
+    required this.gitHash,
+  });
+
+  /// Returns a short display string like "1.0.0 (abc1234)"
+  String get displayString {
+    final shortHash = gitHash.length > 7 ? gitHash.substring(0, 7) : gitHash;
+    return 'v$version ($shortHash)';
+  }
+}
+
+/// Service for retrieving app version information
+class VersionService {
+  VersionService._();
+
+  static final VersionService instance = VersionService._();
+
+  VersionInfo? _cachedInfo;
+
+  /// Get the version info, loading from package info if not cached
+  Future<VersionInfo> getVersionInfo() async {
+    if (_cachedInfo != null) {
+      return _cachedInfo!;
+    }
+
+    final packageInfo = await PackageInfo.fromPlatform();
+    _cachedInfo = VersionInfo(
+      version: packageInfo.version,
+      buildNumber: packageInfo.buildNumber,
+      gitHash: _gitHash,
+    );
+
+    return _cachedInfo!;
+  }
+}
+
+/// Provider for version info (async)
+final versionInfoProvider = FutureProvider<VersionInfo>((ref) async {
+  return VersionService.instance.getVersionInfo();
+});

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -6,11 +6,13 @@ import FlutterMacOS
 import Foundation
 
 import file_picker
+import package_info_plus
 import pdfx
 import sqlite3_flutter_libs
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   FilePickerPlugin.register(with: registry.registrar(forPlugin: "FilePickerPlugin"))
+  FPPPackageInfoPlusPlugin.register(with: registry.registrar(forPlugin: "FPPPackageInfoPlusPlugin"))
   PdfxPlugin.register(with: registry.registrar(forPlugin: "PdfxPlugin"))
   Sqlite3FlutterLibsPlugin.register(with: registry.registrar(forPlugin: "Sqlite3FlutterLibsPlugin"))
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -370,6 +370,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.0"
+  http:
+    dependency: transitive
+    description:
+      name: http
+      sha256: "87721a4a50b19c7f1d49001e51409bddc46303966ce89a65af4f4e6004896412"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.6.0"
   http_multi_server:
     dependency: transitive
     description:
@@ -527,6 +535,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.2.0"
+  package_info_plus:
+    dependency: "direct main"
+    description:
+      name: package_info_plus
+      sha256: "16eee997588c60225bda0488b6dcfac69280a6b7a3cf02c741895dd370a02968"
+      url: "https://pub.dev"
+    source: hosted
+    version: "8.3.1"
+  package_info_plus_platform_interface:
+    dependency: transitive
+    description:
+      name: package_info_plus_platform_interface
+      sha256: "202a487f08836a592a6bd4f901ac69b3a8f146af552bbd14407b6b41e1c3f086"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.2.1"
   path:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -56,6 +56,7 @@ dependencies:
   # Utilities
   uuid: ^4.5.1
   intl: ^0.20.2
+  package_info_plus: ^8.0.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Add version and git commit hash to the AppBar title next to "Open Score". The version comes from pubspec.yaml and the commit hash is passed via --dart-define at build time. The display format is "v1.0.0 (abc1234)".

- Add package_info_plus dependency for version retrieval
- Create VersionService to manage version info and provide Riverpod provider
- Update LibraryScreen AppBar to display version inline with app title
- Update Makefile to pass GIT_HASH via --dart-define to all run and build commands