### PR TITLE
feat: add background PDF page pre-rendering for faster navigation

### DIFF
--- a/lib/screens/pdf_viewer_screen.dart
+++ b/lib/screens/pdf_viewer_screen.dart
@@ -7,6 +7,7 @@ import 'package:drift/drift.dart' as drift;
 import '../models/database.dart';
 import '../services/database_service.dart';
 import '../services/annotation_service.dart';
+import '../widgets/cached_pdf_view.dart';
 import '../widgets/drawing_canvas.dart';
 import '../widgets/layer_panel.dart';
 import '../widgets/annotation_toolbar.dart';
@@ -24,7 +25,7 @@ class PdfViewerScreen extends ConsumerStatefulWidget {
 }
 
 class _PdfViewerScreenState extends ConsumerState<PdfViewerScreen> {
-  PdfController? _pdfController;
+  CachedPdfController? _pdfController;
   DocumentSetting? _settings;
   final FocusNode _focusNode = FocusNode();
 
@@ -79,7 +80,7 @@ class _PdfViewerScreenState extends ConsumerState<PdfViewerScreen> {
         throw Exception('Document not found');
       }
 
-      _pdfController = PdfController(
+      _pdfController = CachedPdfController(
         document: pdfDocument,
         initialPage: _currentPage,
       );
@@ -267,7 +268,7 @@ class _PdfViewerScreenState extends ConsumerState<PdfViewerScreen> {
                   colorFilter: ColorFilter.matrix(_createColorMatrix()),
                   child: Transform.scale(
                     scale: _zoomLevel,
-                    child: PdfView(
+                    child: CachedPdfView(
                       controller: _pdfController!,
                       scrollDirection: Axis.horizontal,
                       pageSnapping: true,

--- a/lib/services/pdf_page_cache_service.dart
+++ b/lib/services/pdf_page_cache_service.dart
@@ -1,0 +1,238 @@
+import 'dart:async';
+import 'package:flutter/foundation.dart';
+import 'package:pdfx/pdfx.dart';
+
+/// Cache key for a rendered PDF page
+class PageCacheKey {
+  final String documentId;
+  final int pageNumber;
+
+  PageCacheKey(this.documentId, this.pageNumber);
+
+  @override
+  bool operator ==(Object other) =>
+      other is PageCacheKey &&
+      other.documentId == documentId &&
+      other.pageNumber == pageNumber;
+
+  @override
+  int get hashCode => Object.hash(documentId, pageNumber);
+
+  @override
+  String toString() => 'PageCacheKey($documentId, $pageNumber)';
+}
+
+/// Cached page image data
+class CachedPageImage {
+  final Uint8List bytes;
+  final int width;
+  final int height;
+  final DateTime cachedAt;
+
+  CachedPageImage({
+    required this.bytes,
+    required this.width,
+    required this.height,
+  }) : cachedAt = DateTime.now();
+}
+
+/// Service for caching and pre-rendering PDF pages
+class PdfPageCacheService {
+  static PdfPageCacheService? _instance;
+  static PdfPageCacheService get instance =>
+      _instance ??= PdfPageCacheService._();
+  PdfPageCacheService._();
+
+  /// Cache of rendered page images
+  final Map<PageCacheKey, CachedPageImage> _cache = {};
+
+  /// Set of pages currently being rendered
+  final Set<PageCacheKey> _rendering = {};
+
+  /// Maximum number of pages to keep in cache per document
+  static const int maxPagesPerDocument = 25;
+
+  /// Number of pages to pre-render ahead and behind current page
+  static const int preRenderRadius = 10;
+
+  /// Get a cached page image
+  CachedPageImage? getCachedPage(String documentId, int pageNumber) {
+    final key = PageCacheKey(documentId, pageNumber);
+    return _cache[key];
+  }
+
+  /// Check if a page is cached
+  bool isPageCached(String documentId, int pageNumber) {
+    return _cache.containsKey(PageCacheKey(documentId, pageNumber));
+  }
+
+  /// Check if a page is currently being rendered
+  bool isPageRendering(String documentId, int pageNumber) {
+    return _rendering.contains(PageCacheKey(documentId, pageNumber));
+  }
+
+  /// Cache a rendered page image
+  void cachePage(String documentId, int pageNumber, CachedPageImage image) {
+    final key = PageCacheKey(documentId, pageNumber);
+    _cache[key] = image;
+    _evictOldPages(documentId);
+  }
+
+  /// Pre-render pages around the current page
+  Future<void> preRenderPages({
+    required PdfDocument document,
+    required int currentPage,
+    required int totalPages,
+    double scale = 2.0,
+  }) async {
+    final documentId = document.id;
+
+    // Calculate pages to pre-render (current page ± radius)
+    final pagesToRender = <int>[];
+    for (int offset = 1; offset <= preRenderRadius; offset++) {
+      // Prioritize forward pages first
+      if (currentPage + offset <= totalPages) {
+        pagesToRender.add(currentPage + offset);
+      }
+      if (currentPage - offset >= 1) {
+        pagesToRender.add(currentPage - offset);
+      }
+    }
+
+    // Pre-render each page in background
+    for (final pageNumber in pagesToRender) {
+      final key = PageCacheKey(documentId, pageNumber);
+
+      // Skip if already cached or being rendered
+      if (_cache.containsKey(key) || _rendering.contains(key)) {
+        continue;
+      }
+
+      // Mark as rendering
+      _rendering.add(key);
+
+      // Render in background
+      unawaited(
+        _renderPage(document: document, pageNumber: pageNumber, scale: scale)
+            .then((_) {
+              _rendering.remove(key);
+            })
+            .catchError((error) {
+              _rendering.remove(key);
+              debugPrint('Error pre-rendering page $pageNumber: $error');
+            }),
+      );
+    }
+  }
+
+  /// Render a single page and cache it
+  Future<CachedPageImage?> _renderPage({
+    required PdfDocument document,
+    required int pageNumber,
+    required double scale,
+  }) async {
+    final documentId = document.id;
+    final key = PageCacheKey(documentId, pageNumber);
+
+    // Check if already cached (might have been cached while waiting)
+    if (_cache.containsKey(key)) {
+      return _cache[key];
+    }
+
+    try {
+      // Get the page
+      final page = await document.getPage(pageNumber);
+
+      try {
+        // Render the page
+        final image = await page.render(
+          width: page.width * scale,
+          height: page.height * scale,
+          format: PdfPageImageFormat.jpeg,
+          backgroundColor: '#ffffff',
+          quality: 85,
+        );
+
+        if (image != null) {
+          final cachedImage = CachedPageImage(
+            bytes: image.bytes,
+            width: image.width ?? (page.width * scale).round(),
+            height: image.height ?? (page.height * scale).round(),
+          );
+
+          _cache[key] = cachedImage;
+          _evictOldPages(documentId);
+
+          return cachedImage;
+        }
+      } finally {
+        await page.close();
+      }
+    } catch (e) {
+      debugPrint('Error rendering page $pageNumber: $e');
+    }
+
+    return null;
+  }
+
+  /// Render a page and return it (also caches it)
+  Future<CachedPageImage?> renderAndCachePage({
+    required PdfDocument document,
+    required int pageNumber,
+    double scale = 2.0,
+  }) async {
+    final documentId = document.id;
+    final key = PageCacheKey(documentId, pageNumber);
+
+    // Return cached version if available
+    if (_cache.containsKey(key)) {
+      return _cache[key];
+    }
+
+    // Mark as rendering
+    _rendering.add(key);
+
+    try {
+      return await _renderPage(
+        document: document,
+        pageNumber: pageNumber,
+        scale: scale,
+      );
+    } finally {
+      _rendering.remove(key);
+    }
+  }
+
+  /// Evict old pages to stay within memory limits
+  void _evictOldPages(String documentId) {
+    // Get all pages for this document
+    final docPages = _cache.entries
+        .where((e) => e.key.documentId == documentId)
+        .toList();
+
+    // If under limit, no eviction needed
+    if (docPages.length <= maxPagesPerDocument) {
+      return;
+    }
+
+    // Sort by cache time (oldest first)
+    docPages.sort((a, b) => a.value.cachedAt.compareTo(b.value.cachedAt));
+
+    // Remove oldest pages until under limit
+    final toRemove = docPages.length - maxPagesPerDocument;
+    for (int i = 0; i < toRemove; i++) {
+      _cache.remove(docPages[i].key);
+    }
+  }
+
+  /// Clear cache for a specific document
+  void clearDocument(String documentId) {
+    _cache.removeWhere((key, _) => key.documentId == documentId);
+  }
+
+  /// Clear entire cache
+  void clearAll() {
+    _cache.clear();
+    _rendering.clear();
+  }
+}

--- a/lib/widgets/cached_pdf_view.dart
+++ b/lib/widgets/cached_pdf_view.dart
@@ -1,0 +1,347 @@
+import 'dart:async';
+import 'package:flutter/material.dart';
+import 'package:pdfx/pdfx.dart';
+import '../services/pdf_page_cache_service.dart';
+
+/// A PDF viewer widget with background page pre-rendering
+class CachedPdfView extends StatefulWidget {
+  const CachedPdfView({
+    required this.controller,
+    this.onPageChanged,
+    this.onDocumentLoaded,
+    this.onDocumentError,
+    this.scrollDirection = Axis.horizontal,
+    this.pageSnapping = true,
+    this.physics,
+    this.backgroundDecoration,
+    super.key,
+  });
+
+  final CachedPdfController controller;
+  final void Function(int page)? onPageChanged;
+  final void Function(PdfDocument document)? onDocumentLoaded;
+  final void Function(Object error)? onDocumentError;
+  final Axis scrollDirection;
+  final bool pageSnapping;
+  final ScrollPhysics? physics;
+  final BoxDecoration? backgroundDecoration;
+
+  @override
+  State<CachedPdfView> createState() => _CachedPdfViewState();
+}
+
+class _CachedPdfViewState extends State<CachedPdfView> {
+  PdfDocument? _document;
+  bool _isLoading = true;
+  Object? _error;
+  bool _initialPreRenderDone = false;
+
+  final _cacheService = PdfPageCacheService.instance;
+
+  @override
+  void initState() {
+    super.initState();
+    _loadDocument();
+  }
+
+  Future<void> _loadDocument() async {
+    try {
+      _document = await widget.controller.document;
+      widget.controller._attach(_document!);
+      widget.onDocumentLoaded?.call(_document!);
+
+      if (mounted) {
+        setState(() => _isLoading = false);
+      }
+    } catch (e) {
+      _error = e;
+      widget.onDocumentError?.call(e);
+      if (mounted) {
+        setState(() => _isLoading = false);
+      }
+    }
+  }
+
+  void _preRenderPages(int currentPage) {
+    if (_document == null) return;
+
+    _cacheService.preRenderPages(
+      document: _document!,
+      currentPage: currentPage,
+      totalPages: _document!.pagesCount,
+    );
+  }
+
+  void _onPageChanged(int pageIndex) {
+    final pageNumber = pageIndex + 1;
+    widget.controller._pageListenable.value = pageNumber;
+    widget.onPageChanged?.call(pageNumber);
+
+    // Pre-render adjacent pages
+    _preRenderPages(pageNumber);
+  }
+
+  void _onPageRendered(int pageNumber) {
+    // Trigger pre-rendering after the first page renders
+    if (!_initialPreRenderDone && pageNumber == widget.controller.initialPage) {
+      _initialPreRenderDone = true;
+      _preRenderPages(pageNumber);
+    }
+  }
+
+  @override
+  void dispose() {
+    widget.controller._detach();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (_isLoading) {
+      return const Center(child: CircularProgressIndicator());
+    }
+
+    if (_error != null) {
+      return Center(child: Text('Error: $_error'));
+    }
+
+    if (_document == null) {
+      return const Center(child: Text('Failed to load document'));
+    }
+
+    return PageView.builder(
+      controller: widget.controller._pageController,
+      scrollDirection: widget.scrollDirection,
+      pageSnapping: widget.pageSnapping,
+      physics: widget.physics,
+      itemCount: _document!.pagesCount,
+      onPageChanged: _onPageChanged,
+      itemBuilder: (context, index) {
+        return _CachedPdfPage(
+          document: _document!,
+          pageNumber: index + 1,
+          backgroundDecoration: widget.backgroundDecoration,
+          onPageRendered: _onPageRendered,
+        );
+      },
+    );
+  }
+}
+
+/// A single PDF page with caching support
+class _CachedPdfPage extends StatefulWidget {
+  const _CachedPdfPage({
+    required this.document,
+    required this.pageNumber,
+    this.backgroundDecoration,
+    this.onPageRendered,
+  });
+
+  final PdfDocument document;
+  final int pageNumber;
+  final BoxDecoration? backgroundDecoration;
+  final void Function(int pageNumber)? onPageRendered;
+
+  @override
+  State<_CachedPdfPage> createState() => _CachedPdfPageState();
+}
+
+class _CachedPdfPageState extends State<_CachedPdfPage> {
+  final _cacheService = PdfPageCacheService.instance;
+  CachedPageImage? _pageImage;
+  bool _isLoading = true;
+  String? _error;
+
+  @override
+  void initState() {
+    super.initState();
+    _loadPage();
+  }
+
+  @override
+  void didUpdateWidget(_CachedPdfPage oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.pageNumber != widget.pageNumber ||
+        oldWidget.document.id != widget.document.id) {
+      _loadPage();
+    }
+  }
+
+  Future<void> _loadPage() async {
+    setState(() {
+      _isLoading = true;
+      _error = null;
+    });
+
+    // Check cache first
+    final cached = _cacheService.getCachedPage(
+      widget.document.id,
+      widget.pageNumber,
+    );
+
+    if (cached != null) {
+      if (mounted) {
+        setState(() {
+          _pageImage = cached;
+          _isLoading = false;
+        });
+        widget.onPageRendered?.call(widget.pageNumber);
+      }
+      return;
+    }
+
+    // Render and cache the page
+    try {
+      final image = await _cacheService.renderAndCachePage(
+        document: widget.document,
+        pageNumber: widget.pageNumber,
+      );
+
+      if (mounted) {
+        setState(() {
+          _pageImage = image;
+          _isLoading = false;
+        });
+        widget.onPageRendered?.call(widget.pageNumber);
+      }
+    } catch (e) {
+      if (mounted) {
+        setState(() {
+          _error = e.toString();
+          _isLoading = false;
+        });
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (_isLoading) {
+      return Container(
+        decoration: widget.backgroundDecoration,
+        child: const Center(child: CircularProgressIndicator()),
+      );
+    }
+
+    if (_error != null) {
+      return Container(
+        decoration: widget.backgroundDecoration,
+        child: Center(child: Text('Error: $_error')),
+      );
+    }
+
+    if (_pageImage == null) {
+      return Container(
+        decoration: widget.backgroundDecoration,
+        child: const Center(child: Text('Failed to render page')),
+      );
+    }
+
+    return Container(
+      decoration: widget.backgroundDecoration,
+      child: PhotoView(
+        imageProvider: MemoryImage(_pageImage!.bytes),
+        minScale: PhotoViewComputedScale.contained * 1.0,
+        maxScale: PhotoViewComputedScale.contained * 3.0,
+        initialScale: PhotoViewComputedScale.contained,
+        backgroundDecoration:
+            widget.backgroundDecoration ??
+            const BoxDecoration(color: Colors.black),
+        heroAttributes: PhotoViewHeroAttributes(
+          tag: '${widget.document.id}-${widget.pageNumber}',
+        ),
+      ),
+    );
+  }
+}
+
+/// Controller for CachedPdfView
+class CachedPdfController {
+  CachedPdfController({
+    required this.document,
+    this.initialPage = 1,
+    this.viewportFraction = 1.0,
+  }) : assert(viewportFraction > 0.0);
+
+  final Future<PdfDocument> document;
+  final int initialPage;
+  final double viewportFraction;
+
+  PdfDocument? _document;
+  late PageController _pageController;
+  final ValueNotifier<int> _pageListenable = ValueNotifier(1);
+
+  /// Current page number (1-indexed)
+  int get page => _pageListenable.value;
+
+  /// Total page count
+  int? get pagesCount => _document?.pagesCount;
+
+  /// Notifier for page changes
+  ValueNotifier<int> get pageListenable => _pageListenable;
+
+  void _attach(PdfDocument document) {
+    _document = document;
+    _pageController = PageController(
+      initialPage: initialPage - 1,
+      viewportFraction: viewportFraction,
+    );
+    _pageListenable.value = initialPage;
+  }
+
+  void _detach() {
+    // No-op for now, but kept for symmetry with attach
+  }
+
+  /// Jump to a specific page (1-indexed)
+  void jumpToPage(int page) {
+    _pageController.jumpToPage(page - 1);
+  }
+
+  /// Animate to a specific page (1-indexed)
+  Future<void> animateToPage(
+    int page, {
+    required Duration duration,
+    required Curve curve,
+  }) {
+    return _pageController.animateToPage(
+      page - 1,
+      duration: duration,
+      curve: curve,
+    );
+  }
+
+  /// Navigate to next page
+  Future<void> nextPage({required Duration duration, required Curve curve}) {
+    final currentPage = _pageController.page?.round() ?? 0;
+    return _pageController.animateToPage(
+      currentPage + 1,
+      duration: duration,
+      curve: curve,
+    );
+  }
+
+  /// Navigate to previous page
+  Future<void> previousPage({
+    required Duration duration,
+    required Curve curve,
+  }) {
+    final currentPage = _pageController.page?.round() ?? 0;
+    return _pageController.animateToPage(
+      currentPage - 1,
+      duration: duration,
+      curve: curve,
+    );
+  }
+
+  /// Dispose the controller
+  void dispose() {
+    _pageController.dispose();
+    _pageListenable.dispose();
+
+    // Clear cache for this document
+    if (_document != null) {
+      PdfPageCacheService.instance.clearDocument(_document!.id);
+    }
+  }
+}

--- a/test/services/pdf_page_cache_service_test.dart
+++ b/test/services/pdf_page_cache_service_test.dart
@@ -1,0 +1,242 @@
+import 'dart:typed_data';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:open_score/services/pdf_page_cache_service.dart';
+
+void main() {
+  group('PageCacheKey', () {
+    test('equality works correctly', () {
+      final key1 = PageCacheKey('doc1', 1);
+      final key2 = PageCacheKey('doc1', 1);
+      final key3 = PageCacheKey('doc1', 2);
+      final key4 = PageCacheKey('doc2', 1);
+
+      expect(key1, equals(key2));
+      expect(key1, isNot(equals(key3)));
+      expect(key1, isNot(equals(key4)));
+    });
+
+    test('hashCode is consistent with equality', () {
+      final key1 = PageCacheKey('doc1', 1);
+      final key2 = PageCacheKey('doc1', 1);
+
+      expect(key1.hashCode, equals(key2.hashCode));
+    });
+
+    test('toString returns readable format', () {
+      final key = PageCacheKey('doc1', 5);
+
+      expect(key.toString(), contains('doc1'));
+      expect(key.toString(), contains('5'));
+    });
+
+    test('can be used as Map key', () {
+      final map = <PageCacheKey, String>{};
+      final key1 = PageCacheKey('doc1', 1);
+      final key2 = PageCacheKey('doc1', 1);
+
+      map[key1] = 'value1';
+      expect(map[key2], equals('value1'));
+    });
+  });
+
+  group('CachedPageImage', () {
+    test('stores bytes correctly', () {
+      final bytes = Uint8List.fromList([1, 2, 3, 4, 5]);
+      final image = CachedPageImage(bytes: bytes, width: 100, height: 200);
+
+      expect(image.bytes, equals(bytes));
+      expect(image.width, equals(100));
+      expect(image.height, equals(200));
+    });
+
+    test('sets cachedAt timestamp on creation', () {
+      final before = DateTime.now();
+      final image = CachedPageImage(
+        bytes: Uint8List(0),
+        width: 100,
+        height: 200,
+      );
+      final after = DateTime.now();
+
+      expect(
+        image.cachedAt.isAfter(before) || image.cachedAt == before,
+        isTrue,
+      );
+      expect(image.cachedAt.isBefore(after) || image.cachedAt == after, isTrue);
+    });
+  });
+
+  group('PdfPageCacheService', () {
+    late PdfPageCacheService service;
+
+    setUp(() {
+      // Get fresh instance and clear it
+      service = PdfPageCacheService.instance;
+      service.clearAll();
+    });
+
+    tearDown(() {
+      service.clearAll();
+    });
+
+    test('singleton instance is consistent', () {
+      final instance1 = PdfPageCacheService.instance;
+      final instance2 = PdfPageCacheService.instance;
+
+      expect(identical(instance1, instance2), isTrue);
+    });
+
+    test('getCachedPage returns null for uncached page', () {
+      final result = service.getCachedPage('doc1', 1);
+
+      expect(result, isNull);
+    });
+
+    test('isPageCached returns false for uncached page', () {
+      final result = service.isPageCached('doc1', 1);
+
+      expect(result, isFalse);
+    });
+
+    test('cachePage stores and retrieves page correctly', () {
+      final image = CachedPageImage(
+        bytes: Uint8List.fromList([1, 2, 3]),
+        width: 100,
+        height: 200,
+      );
+
+      service.cachePage('doc1', 1, image);
+
+      expect(service.isPageCached('doc1', 1), isTrue);
+      expect(service.getCachedPage('doc1', 1), equals(image));
+    });
+
+    test('cachePage stores pages for different documents separately', () {
+      final image1 = CachedPageImage(
+        bytes: Uint8List.fromList([1]),
+        width: 100,
+        height: 200,
+      );
+      final image2 = CachedPageImage(
+        bytes: Uint8List.fromList([2]),
+        width: 100,
+        height: 200,
+      );
+
+      service.cachePage('doc1', 1, image1);
+      service.cachePage('doc2', 1, image2);
+
+      expect(service.getCachedPage('doc1', 1)?.bytes, equals(image1.bytes));
+      expect(service.getCachedPage('doc2', 1)?.bytes, equals(image2.bytes));
+    });
+
+    test('cachePage stores pages for different page numbers separately', () {
+      final image1 = CachedPageImage(
+        bytes: Uint8List.fromList([1]),
+        width: 100,
+        height: 200,
+      );
+      final image2 = CachedPageImage(
+        bytes: Uint8List.fromList([2]),
+        width: 100,
+        height: 200,
+      );
+
+      service.cachePage('doc1', 1, image1);
+      service.cachePage('doc1', 2, image2);
+
+      expect(service.getCachedPage('doc1', 1)?.bytes, equals(image1.bytes));
+      expect(service.getCachedPage('doc1', 2)?.bytes, equals(image2.bytes));
+    });
+
+    test('clearDocument removes only pages for that document', () {
+      final image1 = CachedPageImage(
+        bytes: Uint8List.fromList([1]),
+        width: 100,
+        height: 200,
+      );
+      final image2 = CachedPageImage(
+        bytes: Uint8List.fromList([2]),
+        width: 100,
+        height: 200,
+      );
+
+      service.cachePage('doc1', 1, image1);
+      service.cachePage('doc2', 1, image2);
+      service.clearDocument('doc1');
+
+      expect(service.isPageCached('doc1', 1), isFalse);
+      expect(service.isPageCached('doc2', 1), isTrue);
+    });
+
+    test('clearAll removes all cached pages', () {
+      final image = CachedPageImage(
+        bytes: Uint8List.fromList([1]),
+        width: 100,
+        height: 200,
+      );
+
+      service.cachePage('doc1', 1, image);
+      service.cachePage('doc2', 1, image);
+      service.clearAll();
+
+      expect(service.isPageCached('doc1', 1), isFalse);
+      expect(service.isPageCached('doc2', 1), isFalse);
+    });
+
+    test('cache evicts oldest pages when exceeding maxPagesPerDocument', () {
+      // maxPagesPerDocument is 25, so cache 27 pages
+      for (int i = 1; i <= 27; i++) {
+        final image = CachedPageImage(
+          bytes: Uint8List.fromList([i]),
+          width: 100,
+          height: 200,
+        );
+        service.cachePage('doc1', i, image);
+      }
+
+      // Oldest pages (1, 2) should be evicted, newest should remain
+      expect(service.isPageCached('doc1', 1), isFalse);
+      expect(service.isPageCached('doc1', 2), isFalse);
+      expect(service.isPageCached('doc1', 3), isTrue);
+      expect(service.isPageCached('doc1', 27), isTrue);
+    });
+
+    test('cache eviction is per-document', () {
+      // Fill doc1 cache
+      for (int i = 1; i <= 27; i++) {
+        final image = CachedPageImage(
+          bytes: Uint8List.fromList([i]),
+          width: 100,
+          height: 200,
+        );
+        service.cachePage('doc1', i, image);
+      }
+
+      // Add page to doc2 - should not affect doc1 eviction
+      final doc2Image = CachedPageImage(
+        bytes: Uint8List.fromList([100]),
+        width: 100,
+        height: 200,
+      );
+      service.cachePage('doc2', 1, doc2Image);
+
+      // doc2 page should exist
+      expect(service.isPageCached('doc2', 1), isTrue);
+      // doc1 still has its 25 most recent pages
+      expect(service.isPageCached('doc1', 27), isTrue);
+    });
+
+    test('isPageRendering returns false initially', () {
+      expect(service.isPageRendering('doc1', 1), isFalse);
+    });
+
+    test('preRenderRadius constant is accessible', () {
+      expect(PdfPageCacheService.preRenderRadius, equals(10));
+    });
+
+    test('maxPagesPerDocument constant is accessible', () {
+      expect(PdfPageCacheService.maxPagesPerDocument, equals(25));
+    });
+  });
+}


### PR DESCRIPTION
Implement intelligent page caching with background pre-rendering when viewing PDFs. Pages are pre-rendered after the current page loads, rendering ±10 adjacent pages in the background. The cache stores up to 25 pages per document using LRU eviction. This eliminates latency when navigating to previously unviewed pages while keeping navigation smooth.