### PR TITLE
chore: rename app from Open Score to Feuillet

### DIFF
--- a/.github/WORKFLOWS.md
+++ b/.github/WORKFLOWS.md
@@ -52,20 +52,20 @@ This document describes all GitHub Actions workflows in this repository.
 2. **Build macOS**
    - Runs on: macOS
    - Builds: Release .app
-   - Output: `OpenScore-macOS.zip`
+   - Output: `Feuillet-macOS.zip`
    - Retention: 30 days
 
 3. **Build iOS**
    - Runs on: macOS
    - Builds: Release .app (no codesign)
-   - Output: `OpenScore-iOS.zip`
+   - Output: `Feuillet-iOS.zip`
    - Retention: 30 days
    - Note: Requires signing before installation
 
 4. **Build Web**
    - Runs on: Ubuntu
    - Builds: Release web bundle
-   - Output: `OpenScore-Web.zip`
+   - Output: `Feuillet-Web.zip`
    - Retention: 30 days
 
 ### 3. Release Workflow (`release.yml`)
@@ -80,9 +80,9 @@ This document describes all GitHub Actions workflows in this repository.
 
 **Artifacts:**
 - `app-release.apk` - Android APK
-- `OpenScore-macOS.zip` - macOS app bundle
-- `OpenScore-iOS.zip` - iOS app (needs signing)
-- `OpenScore-Web.zip` - Web build
+- `Feuillet-macOS.zip` - macOS app bundle
+- `Feuillet-iOS.zip` - iOS app (needs signing)
+- `Feuillet-Web.zip` - Web build
 
 **Usage:**
 ```bash
@@ -107,7 +107,7 @@ git push origin v1.0.0
 2. Set source to "GitHub Actions"
 
 **Result:**
-- Web app accessible at: `https://YOUR_USERNAME.github.io/open_score/`
+- Web app accessible at: `https://YOUR_USERNAME.github.io/feuillet/`
 
 ## Secrets Configuration
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,13 +72,13 @@ jobs:
         run: |
           mkdir -p dist
           cd build/macos/Build/Products/Release
-          zip -r "$GITHUB_WORKSPACE/dist/OpenScore-macOS.zip" open_score.app
+          zip -r "$GITHUB_WORKSPACE/dist/Feuillet-macOS.zip" feuillet.app
 
       - name: Upload macOS artifact
         uses: actions/upload-artifact@v6
         with:
           name: macos-app
-          path: dist/OpenScore-macOS.zip
+          path: dist/Feuillet-macOS.zip
           retention-days: 30
 
   build-ios:
@@ -109,13 +109,13 @@ jobs:
         run: |
           mkdir -p dist
           cd build/ios/iphoneos
-          zip -r "$GITHUB_WORKSPACE/dist/OpenScore-iOS.zip" Runner.app
+          zip -r "$GITHUB_WORKSPACE/dist/Feuillet-iOS.zip" Runner.app
 
       - name: Upload iOS artifact
         uses: actions/upload-artifact@v6
         with:
           name: ios-app
-          path: dist/OpenScore-iOS.zip
+          path: dist/Feuillet-iOS.zip
           retention-days: 30
 
   build-web:
@@ -152,11 +152,11 @@ jobs:
       - name: Create web archive
         run: |
           cd build
-          zip -r ../OpenScore-Web.zip web/
+          zip -r ../Feuillet-Web.zip web/
 
       - name: Upload web artifact
         uses: actions/upload-artifact@v6
         with:
           name: web-build
-          path: OpenScore-Web.zip
+          path: Feuillet-Web.zip
           retention-days: 30

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,15 +31,15 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tag_name: ${{ github.ref }}
-          release_name: Open Score v${{ steps.get_version.outputs.version }}
+          release_name: Feuillet v${{ steps.get_version.outputs.version }}
           body: |
-            ## Open Score v${{ steps.get_version.outputs.version }}
+            ## Feuillet v${{ steps.get_version.outputs.version }}
 
             ### Downloads
             - **Android**: `app-release.apk`
-            - **macOS**: `OpenScore-macOS.zip`
-            - **iOS**: `OpenScore-iOS.zip` (requires signing)
-            - **Web**: `OpenScore-Web.zip`
+            - **macOS**: `Feuillet-macOS.zip`
+            - **iOS**: `Feuillet-iOS.zip` (requires signing)
+            - **Web**: `Feuillet-Web.zip`
 
             ### Installation
             - **Android**: Download and install the APK
@@ -68,22 +68,22 @@ jobs:
           - os: macos-latest
             platform: macos
             build-cmd: flutter build macos --release
-            artifact-path: OpenScore-macOS.zip
-            artifact-name: OpenScore-macOS.zip
+            artifact-path: Feuillet-macOS.zip
+            artifact-name: Feuillet-macOS.zip
             content-type: application/zip
 
           - os: macos-latest
             platform: ios
             build-cmd: flutter build ios --release --no-codesign
-            artifact-path: OpenScore-iOS.zip
-            artifact-name: OpenScore-iOS.zip
+            artifact-path: Feuillet-iOS.zip
+            artifact-name: Feuillet-iOS.zip
             content-type: application/zip
 
           - os: ubuntu-latest
             platform: web
             build-cmd: flutter build web --release
-            artifact-path: OpenScore-Web.zip
-            artifact-name: OpenScore-Web.zip
+            artifact-path: Feuillet-Web.zip
+            artifact-name: Feuillet-Web.zip
             content-type: application/zip
 
     runs-on: ${{ matrix.os }}
@@ -123,20 +123,20 @@ jobs:
         if: matrix.platform == 'macos'
         run: |
           cd build/macos/Build/Products/Release
-          zip -r "$GITHUB_WORKSPACE/OpenScore-macOS.zip" open_score.app
+          zip -r "$GITHUB_WORKSPACE/Feuillet-macOS.zip" feuillet.app
 
       - name: Prepare iOS artifact
         if: matrix.platform == 'ios'
         run: |
           cd build/ios/iphoneos
-          zip -r "$GITHUB_WORKSPACE/OpenScore-iOS.zip" Runner.app
+          zip -r "$GITHUB_WORKSPACE/Feuillet-iOS.zip" Runner.app
 
       - name: Prepare web artifact
         if: matrix.platform == 'web'
         run: |
           cp -f web/sqlite3.wasm web/drift_worker.js build/web/
           cd build
-          zip -r ../OpenScore-Web.zip web/
+          zip -r ../Feuillet-Web.zip web/
 
       - name: Upload Release Asset
         uses: actions/upload-release-asset@v1

--- a/.gitignore
+++ b/.gitignore
@@ -44,8 +44,8 @@ app.*.map.json
 /android/app/profile
 /android/app/release
 
-# Open Score specific - Local data directory
-open_score/
+# Feuillet specific - Local data directory
+feuillet/
 *.sqlite
 *.sqlite-wal
 *.sqlite-shm

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-All notable changes to Open Score will be documented in this file.
+All notable changes to Feuillet will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
@@ -42,5 +42,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Auto-hiding controls in viewer mode
 - Dark mode support
 
-[Unreleased]: https://github.com/yourusername/open_score/compare/v0.1.0...HEAD
-[0.1.0]: https://github.com/yourusername/open_score/releases/tag/v0.1.0
+[Unreleased]: https://github.com/yourusername/feuillet/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/yourusername/feuillet/releases/tag/v0.1.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-Open Score is a forScore clone built with Flutter - a PDF sheet music reader with multi-layer annotation support and set list management. The app is designed for **local-only operation** with Syncthing for cross-device synchronization.
+Feuillet is a forScore clone built with Flutter - a PDF sheet music reader with multi-layer annotation support and set list management. The app is designed for **local-only operation** with Syncthing for cross-device synchronization.
 
 ## Essential Commands
 
@@ -192,7 +192,7 @@ Annotations use a **multi-layer system**:
 
 `FileWatcherService` monitors two directories:
 - PDF directory (`pdfs/`)
-- Database file (`open_score_db.sqlite` + WAL files)
+- Database file (`feuillet_db.sqlite` + WAL files)
 
 **Filters Syncthing temporary files:**
 - `.syncthing.*`
@@ -273,17 +273,17 @@ Annotations are **JSON-serialized** in the database. To add new annotation types
 
 ## Data Storage Locations
 
-- **macOS**: `~/Library/Application Support/com.openscore.openScore/open_score/`
-- **Android**: `/data/data/com.openscore.open_score/app_flutter/open_score/`
+- **macOS**: `~/Library/Application Support/com.feuillet.app/feuillet/`
+- **Android**: `/data/data/com.feuillet.feuillet/app_flutter/feuillet/`
 - **iOS**: App Documents directory
 
 Structure:
 ```
-open_score/
+feuillet/
 ├── pdfs/                    # PDF files
-├── open_score_db.sqlite     # Main database
-├── open_score_db.sqlite-wal # WAL file
-└── open_score_db.sqlite-shm # Shared memory file
+├── feuillet_db.sqlite     # Main database
+├── feuillet_db.sqlite-wal # WAL file
+└── feuillet_db.sqlite-shm # Shared memory file
 ```
 
 ## Known Issues & Workarounds

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
-# Contributing to Open Score
+# Contributing to Feuillet
 
-Thank you for your interest in contributing to Open Score! This document provides guidelines and instructions for contributing.
+Thank you for your interest in contributing to Feuillet! This document provides guidelines and instructions for contributing.
 
 ## Code of Conduct
 
@@ -13,8 +13,8 @@ Thank you for your interest in contributing to Open Score! This document provide
 1. **Fork the repository** on GitHub
 2. **Clone your fork** locally:
    ```bash
-   git clone https://github.com/YOUR_USERNAME/open_score.git
-   cd open_score
+   git clone https://github.com/YOUR_USERNAME/feuillet.git
+   cd feuillet
    ```
 3. **Set up the project**:
    ```bash

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ GIT_HASH := $(shell git rev-parse --short HEAD 2>/dev/null || echo "unknown")
 
 # Default target
 help:
-	@echo "Open Score - Development Makefile"
+	@echo "Feuillet - Development Makefile"
 	@echo ""
 	@echo "Setup & Dependencies:"
 	@echo "  make setup           - Install dependencies and setup project from scratch"
@@ -38,7 +38,7 @@ help:
 
 # Setup project from scratch
 setup:
-	@echo "🔧 Setting up Open Score project..."
+	@echo "🔧 Setting up Feuillet project..."
 	flutter pub get
 	@echo ""
 	@echo "🗄️  Generating database code..."

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-# Open Score
+# Feuillet
 
-[![CI](https://github.com/vinzd/open_score/workflows/CI/badge.svg)](https://github.com/vinzd/open_score/actions/workflows/ci.yml)
-[![Build](https://github.com/vinzd/open_score/workflows/Build%20All%20Platforms/badge.svg)](https://github.com/vinzd/open_score/actions/workflows/build.yml)
+[![CI](https://github.com/vinzd/feuillet/workflows/CI/badge.svg)](https://github.com/vinzd/feuillet/actions/workflows/ci.yml)
+[![Build](https://github.com/vinzd/feuillet/workflows/Build%20All%20Platforms/badge.svg)](https://github.com/vinzd/feuillet/actions/workflows/build.yml)
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 [![Flutter](https://img.shields.io/badge/Flutter-3.38.8-02569B?logo=flutter)](https://flutter.dev)
 
@@ -9,7 +9,7 @@ A forScore clone built with Flutter - a powerful PDF sheet music reader with ann
 
 ## 🌐 Try It Online
 
-**[Launch Web Demo](https://vinzd.github.io/open_score/)** - Test Open Score directly in your browser
+**[Launch Web Demo](https://vinzd.github.io/feuillet/)** - Test Feuillet directly in your browser
 
 > **Note:** The web version has limitations - PDFs are stored in browser storage (not file system), and Syncthing integration is not available. For full functionality, use the native macOS, iOS, or Android apps.
 
@@ -126,7 +126,7 @@ make build-web      # Build for web
 
 1. **Clone the repository**
    ```bash
-   cd open_score
+   cd feuillet
    ```
 
 2. **Install dependencies**
@@ -181,22 +181,22 @@ make build-web      # Build for web
 - **Android**: Install from [Google Play](https://play.google.com/store/apps/details?id=com.nutomic.syncthingandroid)
 - **iOS**: Use [Möbius Sync](https://apps.apple.com/app/mobius-sync/id1539203216)
 
-### 2. Locate Open Score Data Directory
+### 2. Locate Feuillet Data Directory
 
 The app stores data in:
-- **macOS**: `~/Library/Application Support/com.openscore.openScore/open_score/`
-- **Android**: `/data/data/com.openscore.open_score/app_flutter/open_score/`
+- **macOS**: `~/Library/Application Support/com.feuillet.app/feuillet/`
+- **Android**: `/data/data/com.feuillet.feuillet/app_flutter/feuillet/`
 - **iOS**: App's Documents directory
 
 You can find the exact path in the app by checking debug logs or settings.
 
 ### 3. Configure Syncthing
 
-1. Create a new folder in Syncthing pointing to the Open Score directory
+1. Create a new folder in Syncthing pointing to the Feuillet directory
 2. Share this folder with your other devices
 3. The folder contains:
    - `pdfs/` - Your PDF files
-   - `open_score_db.sqlite` - The database
+   - `feuillet_db.sqlite` - The database
    - Database WAL files (`.sqlite-wal`, `.sqlite-shm`)
 
 ### 4. Important Syncthing Settings
@@ -207,7 +207,7 @@ You can find the exact path in the app by checking debug logs or settings.
 
 ### 5. How It Works
 
-1. Open Score monitors the PDF directory and database file
+1. Feuillet monitors the PDF directory and database file
 2. When Syncthing syncs changes, the file watcher detects them
 3. The app automatically:
    - Reloads the database
@@ -225,7 +225,7 @@ You can find the exact path in the app by checking debug logs or settings.
 ### Importing PDFs
 1. Tap the **+** button in the Library screen
 2. Select a PDF file from your device
-3. The file is copied to Open Score's managed directory
+3. The file is copied to Feuillet's managed directory
 4. Alternatively, add PDFs directly via Syncthing
 
 ### Viewing PDFs

--- a/TEST_README.md
+++ b/TEST_README.md
@@ -1,6 +1,6 @@
-# Open Score Test Suite
+# Feuillet Test Suite
 
-This document describes the comprehensive test suite for Open Score.
+This document describes the comprehensive test suite for Feuillet.
 
 ## Test Structure
 
@@ -212,7 +212,7 @@ These areas require additional test infrastructure (mocks, test databases, etc.)
 
 ```dart
 import 'package:flutter_test/flutter_test.dart';
-import 'package:open_score/path/to/component.dart';
+import 'package:feuillet/path/to/component.dart';
 
 void main() {
   group('ComponentName', () {
@@ -246,7 +246,7 @@ void main() {
 ```dart
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:open_score/widgets/my_widget.dart';
+import 'package:feuillet/widgets/my_widget.dart';
 
 void main() {
   testWidgets('MyWidget displays correctly', (WidgetTester tester) async {

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 }
 
 android {
-    namespace = "com.openscore.open_score"
+    namespace = "com.feuillet.app"
     compileSdk = flutter.compileSdkVersion
     ndkVersion = flutter.ndkVersion
 
@@ -21,7 +21,7 @@ android {
 
     defaultConfig {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
-        applicationId = "com.openscore.open_score"
+        applicationId = "com.feuillet.app"
         // minSdk 24 required for drift_flutter/sqlite3_flutter_libs
         minSdk = 24
         targetSdk = flutter.targetSdkVersion

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,6 +1,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <application
-        android:label="open_score"
+        android:label="Feuillet"
         android:name="${applicationName}"
         android:icon="@mipmap/ic_launcher">
         <activity

--- a/integration_test/app_test.dart
+++ b/integration_test/app_test.dart
@@ -1,6 +1,6 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
-import 'package:open_score/main.dart';
+import 'package:feuillet/main.dart';
 
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
@@ -10,7 +10,7 @@ void main() {
       // Note: These tests require proper initialization of services
       // which may need to be mocked or configured for testing
 
-      await tester.pumpWidget(const OpenScoreApp());
+      await tester.pumpWidget(const FeuilletApp());
       await tester.pumpAndSettle();
 
       // Verify basic navigation is present
@@ -19,7 +19,7 @@ void main() {
     });
 
     testWidgets('can navigate between tabs', (WidgetTester tester) async {
-      await tester.pumpWidget(const OpenScoreApp());
+      await tester.pumpWidget(const FeuilletApp());
       await tester.pumpAndSettle();
 
       // Start on Library tab

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -368,7 +368,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.openscore.openScore;
+				PRODUCT_BUNDLE_IDENTIFIER = com.feuillet.app;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
@@ -384,7 +384,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.openscore.openScore.RunnerTests;
+				PRODUCT_BUNDLE_IDENTIFIER = com.feuillet.app.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -401,7 +401,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.openscore.openScore.RunnerTests;
+				PRODUCT_BUNDLE_IDENTIFIER = com.feuillet.app.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Runner.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Runner";
@@ -416,7 +416,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.openscore.openScore.RunnerTests;
+				PRODUCT_BUNDLE_IDENTIFIER = com.feuillet.app.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Runner.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Runner";
@@ -547,7 +547,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.openscore.openScore;
+				PRODUCT_BUNDLE_IDENTIFIER = com.feuillet.app;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -569,7 +569,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.openscore.openScore;
+				PRODUCT_BUNDLE_IDENTIFIER = com.feuillet.app;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -5,7 +5,7 @@
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleDisplayName</key>
-	<string>Open Score</string>
+	<string>Feuillet</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
@@ -13,7 +13,7 @@
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>
-	<string>open_score</string>
+	<string>Feuillet</string>
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -22,11 +22,11 @@ void main() async {
     PdfService.instance;
   }
 
-  runApp(const ProviderScope(child: OpenScoreApp()));
+  runApp(const ProviderScope(child: FeuilletApp()));
 }
 
-class OpenScoreApp extends ConsumerWidget {
-  const OpenScoreApp({super.key});
+class FeuilletApp extends ConsumerWidget {
+  const FeuilletApp({super.key});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -34,7 +34,7 @@ class OpenScoreApp extends ConsumerWidget {
 
     return AppLifecycleManager(
       child: MaterialApp.router(
-        title: 'Open Score',
+        title: 'Feuillet',
         debugShowCheckedModeBanner: false,
         theme: _buildTheme(Brightness.light),
         darkTheme: _buildTheme(Brightness.dark),

--- a/lib/models/database.dart
+++ b/lib/models/database.dart
@@ -307,7 +307,7 @@ class AppDatabase extends _$AppDatabase {
 // Connection configuration with WAL mode for better Syncthing compatibility
 QueryExecutor _openConnection() {
   return driftDatabase(
-    name: 'open_score_db',
+    name: 'feuillet_db',
     web: DriftWebOptions(
       sqlite3Wasm: Uri.parse('sqlite3.wasm'),
       driftWorker: Uri.parse('drift_worker.js'),

--- a/lib/screens/library_screen.dart
+++ b/lib/screens/library_screen.dart
@@ -713,7 +713,7 @@ class _LibraryScreenState extends ConsumerState<LibraryScreen> {
       title: Row(
         mainAxisSize: MainAxisSize.min,
         children: [
-          const Text('Open Score'),
+          const Text('Feuillet'),
           const SizedBox(width: 8),
           versionInfo.when(
             data: (info) => Text(

--- a/lib/services/app_settings_service.dart
+++ b/lib/services/app_settings_service.dart
@@ -52,7 +52,7 @@ class AppSettingsService {
 
     // Return default path
     final appDocDir = await getApplicationDocumentsDirectory();
-    _cachedPdfPath = p.join(appDocDir.path, 'open_score', 'pdfs');
+    _cachedPdfPath = p.join(appDocDir.path, 'feuillet', 'pdfs');
     return _cachedPdfPath!;
   }
 

--- a/lib/services/file_watcher_service.dart
+++ b/lib/services/file_watcher_service.dart
@@ -53,11 +53,7 @@ class FileWatcherService {
 
       // Database path always stays in app documents
       final appDocDir = await getApplicationDocumentsDirectory();
-      _databasePath = p.join(
-        appDocDir.path,
-        'open_score',
-        'open_score_db.sqlite',
-      );
+      _databasePath = p.join(appDocDir.path, 'feuillet', 'feuillet_db.sqlite');
 
       // Create PDF directory if it doesn't exist
       final pdfDir = Directory(_pdfDirectoryPath!);
@@ -223,7 +219,7 @@ class FileWatcherService {
     }
 
     final appDocDir = await getApplicationDocumentsDirectory();
-    return p.join(appDocDir.path, 'open_score');
+    return p.join(appDocDir.path, 'feuillet');
   }
 
   /// Dispose resources

--- a/macos/Runner.xcodeproj/project.pbxproj
+++ b/macos/Runner.xcodeproj/project.pbxproj
@@ -64,7 +64,7 @@
 		331C80D7294CF71000263BE5 /* RunnerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RunnerTests.swift; sourceTree = "<group>"; };
 		333000ED22D3DE5D00554162 /* Warnings.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Warnings.xcconfig; sourceTree = "<group>"; };
 		335BBD1A22A9A15E00E9071D /* GeneratedPluginRegistrant.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GeneratedPluginRegistrant.swift; sourceTree = "<group>"; };
-		33CC10ED2044A3C60003C045 /* open_score.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "open_score.app"; sourceTree = BUILT_PRODUCTS_DIR; };
+		33CC10ED2044A3C60003C045 /* feuillet.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "feuillet.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		33CC10F02044A3C60003C045 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		33CC10F22044A3C60003C045 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Assets.xcassets; path = Runner/Assets.xcassets; sourceTree = "<group>"; };
 		33CC10F52044A3C60003C045 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = Base; path = Base.lproj/MainMenu.xib; sourceTree = "<group>"; };
@@ -131,7 +131,7 @@
 		33CC10EE2044A3C60003C045 /* Products */ = {
 			isa = PBXGroup;
 			children = (
-				33CC10ED2044A3C60003C045 /* open_score.app */,
+				33CC10ED2044A3C60003C045 /* feuillet.app */,
 				331C80D5294CF71000263BE5 /* RunnerTests.xctest */,
 			);
 			name = Products;
@@ -217,7 +217,7 @@
 			);
 			name = Runner;
 			productName = Runner;
-			productReference = 33CC10ED2044A3C60003C045 /* open_score.app */;
+			productReference = 33CC10ED2044A3C60003C045 /* feuillet.app */;
 			productType = "com.apple.product-type.application";
 		};
 /* End PBXNativeTarget section */
@@ -385,10 +385,10 @@
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.openscore.openScore.RunnerTests;
+				PRODUCT_BUNDLE_IDENTIFIER = com.feuillet.app.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
-				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/open_score.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/open_score";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/feuillet.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Feuillet";
 			};
 			name = Debug;
 		};
@@ -399,10 +399,10 @@
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.openscore.openScore.RunnerTests;
+				PRODUCT_BUNDLE_IDENTIFIER = com.feuillet.app.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
-				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/open_score.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/open_score";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/feuillet.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Feuillet";
 			};
 			name = Release;
 		};
@@ -413,10 +413,10 @@
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.openscore.openScore.RunnerTests;
+				PRODUCT_BUNDLE_IDENTIFIER = com.feuillet.app.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
-				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/open_score.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/open_score";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/feuillet.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Feuillet";
 			};
 			name = Profile;
 		};

--- a/macos/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/macos/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -15,7 +15,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "33CC10EC2044A3C60003C045"
-               BuildableName = "open_score.app"
+               BuildableName = "feuillet.app"
                BlueprintName = "Runner"
                ReferencedContainer = "container:Runner.xcodeproj">
             </BuildableReference>
@@ -31,7 +31,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "33CC10EC2044A3C60003C045"
-            BuildableName = "open_score.app"
+            BuildableName = "feuillet.app"
             BlueprintName = "Runner"
             ReferencedContainer = "container:Runner.xcodeproj">
          </BuildableReference>
@@ -66,7 +66,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "33CC10EC2044A3C60003C045"
-            BuildableName = "open_score.app"
+            BuildableName = "feuillet.app"
             BlueprintName = "Runner"
             ReferencedContainer = "container:Runner.xcodeproj">
          </BuildableReference>
@@ -83,7 +83,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "33CC10EC2044A3C60003C045"
-            BuildableName = "open_score.app"
+            BuildableName = "feuillet.app"
             BlueprintName = "Runner"
             ReferencedContainer = "container:Runner.xcodeproj">
          </BuildableReference>

--- a/macos/Runner/Configs/AppInfo.xcconfig
+++ b/macos/Runner/Configs/AppInfo.xcconfig
@@ -5,10 +5,10 @@
 // 'flutter create' template.
 
 // The application's name. By default this is also the title of the Flutter window.
-PRODUCT_NAME = open_score
+PRODUCT_NAME = Feuillet
 
 // The application's bundle identifier
-PRODUCT_BUNDLE_IDENTIFIER = com.openscore.openScore
+PRODUCT_BUNDLE_IDENTIFIER = com.feuillet.app
 
 // The copyright displayed in application information
-PRODUCT_COPYRIGHT = Copyright © 2026 com.openscore. All rights reserved.
+PRODUCT_COPYRIGHT = Copyright © 2026 Feuillet. All rights reserved.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,4 +1,4 @@
-name: open_score
+name: feuillet
 description: "A new Flutter project."
 # The following line prevents the package from being accidentally published to
 # pub.dev using `flutter pub publish`. This is preferred for private packages.

--- a/test/models/database_integration_test.dart
+++ b/test/models/database_integration_test.dart
@@ -1,7 +1,7 @@
 import 'package:drift/drift.dart' hide isNull, isNotNull;
 import 'package:drift/native.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:open_score/models/database.dart';
+import 'package:feuillet/models/database.dart';
 
 /// Creates an in-memory database for testing
 AppDatabase createTestDatabase() {

--- a/test/models/database_test.dart
+++ b/test/models/database_test.dart
@@ -1,5 +1,5 @@
 import 'package:flutter_test/flutter_test.dart';
-import 'package:open_score/models/database.dart';
+import 'package:feuillet/models/database.dart';
 
 void main() {
   group('Database Models', () {

--- a/test/models/view_mode_test.dart
+++ b/test/models/view_mode_test.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:open_score/models/view_mode.dart';
+import 'package:feuillet/models/view_mode.dart';
 
 void main() {
   group('PdfViewMode', () {

--- a/test/router/app_router_test.dart
+++ b/test/router/app_router_test.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
-import 'package:open_score/router/app_router.dart';
+import 'package:feuillet/router/app_router.dart';
 
 void main() {
   group('AppRoutes', () {

--- a/test/screens/home_screen_test.dart
+++ b/test/screens/home_screen_test.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:open_score/screens/home_screen.dart';
+import 'package:feuillet/screens/home_screen.dart';
 
 void main() {
   group('HomeScreen', () {

--- a/test/screens/library_screen_selection_test.dart
+++ b/test/screens/library_screen_selection_test.dart
@@ -1,5 +1,5 @@
 import 'package:flutter_test/flutter_test.dart';
-import 'package:open_score/models/database.dart';
+import 'package:feuillet/models/database.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();

--- a/test/screens/pdf_viewer_zoom_pan_test.dart
+++ b/test/screens/pdf_viewer_zoom_pan_test.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:open_score/utils/display_settings.dart';
-import 'package:open_score/utils/zoom_pan_gesture_handler.dart';
+import 'package:feuillet/utils/display_settings.dart';
+import 'package:feuillet/utils/zoom_pan_gesture_handler.dart';
 
 /// Tests for PDF viewer zoom and pan functionality.
 /// Note: Full widget tests are difficult due to pdfx dependency.

--- a/test/screens/wrappers/pdf_viewer_wrapper_test.dart
+++ b/test/screens/wrappers/pdf_viewer_wrapper_test.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:open_score/screens/wrappers/pdf_viewer_wrapper.dart';
+import 'package:feuillet/screens/wrappers/pdf_viewer_wrapper.dart';
 
 void main() {
   group('documentByIdProvider', () {

--- a/test/screens/wrappers/setlist_performance_wrapper_test.dart
+++ b/test/screens/wrappers/setlist_performance_wrapper_test.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:open_score/screens/wrappers/setlist_performance_wrapper.dart';
+import 'package:feuillet/screens/wrappers/setlist_performance_wrapper.dart';
 
 void main() {
   group('setListWithDocumentsProvider', () {

--- a/test/services/annotation_service_test.dart
+++ b/test/services/annotation_service_test.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:open_score/services/annotation_service.dart';
+import 'package:feuillet/services/annotation_service.dart';
 
 void main() {
   group('DrawingStroke', () {

--- a/test/services/pdf_export_service_test.dart
+++ b/test/services/pdf_export_service_test.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:open_score/services/annotation_service.dart';
-import 'package:open_score/services/pdf_export_service.dart';
+import 'package:feuillet/services/annotation_service.dart';
+import 'package:feuillet/services/pdf_export_service.dart';
 
 void main() {
   group('PdfExportService', () {

--- a/test/services/pdf_page_cache_service_test.dart
+++ b/test/services/pdf_page_cache_service_test.dart
@@ -1,6 +1,6 @@
 import 'dart:typed_data';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:open_score/services/pdf_page_cache_service.dart';
+import 'package:feuillet/services/pdf_page_cache_service.dart';
 
 void main() {
   group('PageCacheKey', () {

--- a/test/services/pdf_service_test.dart
+++ b/test/services/pdf_service_test.dart
@@ -1,5 +1,5 @@
 import 'package:flutter_test/flutter_test.dart';
-import 'package:open_score/services/pdf_service.dart';
+import 'package:feuillet/services/pdf_service.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();

--- a/test/services/setlist_service_test.dart
+++ b/test/services/setlist_service_test.dart
@@ -1,5 +1,5 @@
 import 'package:flutter_test/flutter_test.dart';
-import 'package:open_score/services/setlist_service.dart';
+import 'package:feuillet/services/setlist_service.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();

--- a/test/utils/auto_hide_controller_test.dart
+++ b/test/utils/auto_hide_controller_test.dart
@@ -1,5 +1,5 @@
 import 'package:flutter_test/flutter_test.dart';
-import 'package:open_score/utils/auto_hide_controller.dart';
+import 'package:feuillet/utils/auto_hide_controller.dart';
 
 void main() {
   group('AutoHideController', () {

--- a/test/utils/display_settings_test.dart
+++ b/test/utils/display_settings_test.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:open_score/utils/display_settings.dart';
+import 'package:feuillet/utils/display_settings.dart';
 
 void main() {
   group('DisplaySettings', () {

--- a/test/utils/page_spread_calculator_test.dart
+++ b/test/utils/page_spread_calculator_test.dart
@@ -1,6 +1,6 @@
 import 'package:flutter_test/flutter_test.dart';
-import 'package:open_score/models/view_mode.dart';
-import 'package:open_score/utils/page_spread_calculator.dart';
+import 'package:feuillet/models/view_mode.dart';
+import 'package:feuillet/utils/page_spread_calculator.dart';
 
 void main() {
   group('PageSpreadCalculator', () {

--- a/test/utils/zoom_pan_gesture_handler_test.dart
+++ b/test/utils/zoom_pan_gesture_handler_test.dart
@@ -1,8 +1,8 @@
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:open_score/utils/display_settings.dart';
-import 'package:open_score/utils/zoom_pan_gesture_handler.dart';
+import 'package:feuillet/utils/display_settings.dart';
+import 'package:feuillet/utils/zoom_pan_gesture_handler.dart';
 
 void main() {
   group('ZoomPanState', () {

--- a/test/web_url_strategy_test.dart
+++ b/test/web_url_strategy_test.dart
@@ -1,5 +1,5 @@
 import 'package:flutter_test/flutter_test.dart';
-import 'package:open_score/web_url_strategy.dart';
+import 'package:feuillet/web_url_strategy.dart';
 
 void main() {
   group('configureUrlStrategy', () {

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -1,17 +1,17 @@
-// Basic widget test for Open Score
+// Basic widget test for Feuillet
 
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:open_score/main.dart';
+import 'package:feuillet/main.dart';
 
 void main() {
-  // Note: This test is skipped because OpenScoreApp initializes FileWatcherService
+  // Note: This test is skipped because FeuilletApp initializes FileWatcherService
   // which creates background timers that don't complete before test teardown.
   // Component-level tests in other test files provide better coverage without
   // triggering background services.
   testWidgets('App launches successfully', (WidgetTester tester) async {
     // Build our app and trigger a frame.
-    await tester.pumpWidget(const ProviderScope(child: OpenScoreApp()));
+    await tester.pumpWidget(const ProviderScope(child: FeuilletApp()));
 
     // Verify that app launches and shows navigation
     expect(find.text('Library'), findsOneWidget);

--- a/test/widgets/drawing_canvas_test.dart
+++ b/test/widgets/drawing_canvas_test.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:open_score/services/annotation_service.dart';
-import 'package:open_score/widgets/drawing_canvas.dart';
+import 'package:feuillet/services/annotation_service.dart';
+import 'package:feuillet/widgets/drawing_canvas.dart';
 
 void main() {
   group('DrawingCanvas Widget', () {

--- a/test/widgets/export_pdf_dialog_test.dart
+++ b/test/widgets/export_pdf_dialog_test.dart
@@ -1,5 +1,5 @@
 import 'package:flutter_test/flutter_test.dart';
-import 'package:open_score/widgets/export_pdf_dialog.dart';
+import 'package:feuillet/widgets/export_pdf_dialog.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();

--- a/test/widgets/floating_annotations_panel_test.dart
+++ b/test/widgets/floating_annotations_panel_test.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:open_score/services/annotation_service.dart';
-import 'package:open_score/widgets/floating_annotations_panel.dart';
+import 'package:feuillet/services/annotation_service.dart';
+import 'package:feuillet/widgets/floating_annotations_panel.dart';
 
 /// FloatingAnnotationsPanel widget tests.
 ///

--- a/test/widgets/pdf_card_test.dart
+++ b/test/widgets/pdf_card_test.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:open_score/models/database.dart';
-import 'package:open_score/widgets/pdf_card.dart';
+import 'package:feuillet/models/database.dart';
+import 'package:feuillet/widgets/pdf_card.dart';
 
 void main() {
   group('PdfCard Widget', () {

--- a/test/widgets/pdf_list_tile_test.dart
+++ b/test/widgets/pdf_list_tile_test.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:open_score/models/database.dart';
-import 'package:open_score/screens/library_screen.dart';
+import 'package:feuillet/models/database.dart';
+import 'package:feuillet/screens/library_screen.dart';
 
 void main() {
   group('PdfListTile Widget', () {

--- a/test/widgets/performance_bottom_controls_test.dart
+++ b/test/widgets/performance_bottom_controls_test.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:open_score/models/view_mode.dart';
-import 'package:open_score/widgets/performance_bottom_controls.dart';
+import 'package:feuillet/models/view_mode.dart';
+import 'package:feuillet/widgets/performance_bottom_controls.dart';
 
 void main() {
   group('PerformanceBottomControls', () {

--- a/test/widgets/performance_document_view_test.dart
+++ b/test/widgets/performance_document_view_test.dart
@@ -1,6 +1,6 @@
 import 'package:flutter_test/flutter_test.dart';
-import 'package:open_score/models/view_mode.dart';
-import 'package:open_score/utils/page_spread_calculator.dart';
+import 'package:feuillet/models/view_mode.dart';
+import 'package:feuillet/utils/page_spread_calculator.dart';
 
 /// Tests for PerformanceDocumentView widget logic
 /// Note: Full widget tests are difficult due to pdfx dependency.

--- a/test/widgets/setlist_picker_dialog_test.dart
+++ b/test/widgets/setlist_picker_dialog_test.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:open_score/widgets/setlist_picker_dialog.dart';
+import 'package:feuillet/widgets/setlist_picker_dialog.dart';
 
 void main() {
   group('SetListPickerDialog', () {

--- a/test/widgets/two_page_pdf_view_test.dart
+++ b/test/widgets/two_page_pdf_view_test.dart
@@ -1,6 +1,6 @@
 import 'package:flutter_test/flutter_test.dart';
-import 'package:open_score/models/view_mode.dart';
-import 'package:open_score/widgets/two_page_pdf_view.dart';
+import 'package:feuillet/models/view_mode.dart';
+import 'package:feuillet/widgets/two_page_pdf_view.dart';
 
 /// TwoPagePdfView widget tests.
 ///

--- a/web/index.html
+++ b/web/index.html
@@ -23,13 +23,13 @@
   <!-- iOS meta tags & icons -->
   <meta name="mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-status-bar-style" content="black">
-  <meta name="apple-mobile-web-app-title" content="open_score">
+  <meta name="apple-mobile-web-app-title" content="Feuillet">
   <link rel="apple-touch-icon" href="icons/Icon-192.png">
 
   <!-- Favicon -->
   <link rel="icon" type="image/png" href="favicon.png"/>
 
-  <title>open_score</title>
+  <title>Feuillet</title>
   <link rel="manifest" href="manifest.json">
 </head>
 <body>

--- a/web/manifest.json
+++ b/web/manifest.json
@@ -1,11 +1,11 @@
 {
-    "name": "open_score",
-    "short_name": "open_score",
+    "name": "Feuillet",
+    "short_name": "Feuillet",
     "start_url": ".",
     "display": "standalone",
     "background_color": "#0175C2",
     "theme_color": "#0175C2",
-    "description": "A new Flutter project.",
+    "description": "PDF sheet music reader with annotations",
     "orientation": "portrait-primary",
     "prefer_related_applications": false,
     "icons": [


### PR DESCRIPTION
Comprehensive rename across the entire codebase:
- Package name: open_score → feuillet
- Bundle ID: com.openscore.openScore → com.feuillet.app
- Database: open_score_db → feuillet_db
- All platform configs, documentation, and tests updated