### PR TITLE
chore: upgrade dependencies

### DIFF
--- a/lib/services/pdf_export_service.dart
+++ b/lib/services/pdf_export_service.dart
@@ -222,8 +222,11 @@ class PdfExportService {
     final file = File(filePath);
     await file.writeAsBytes(pdfBytes);
 
-    await Share.shareXFiles([
-      XFile(filePath, mimeType: 'application/pdf'),
-    ], subject: fileName);
+    await SharePlus.instance.share(
+      ShareParams(
+        files: [XFile(filePath, mimeType: 'application/pdf')],
+        subject: fileName,
+      ),
+    );
   }
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -382,10 +382,10 @@ packages:
     dependency: "direct main"
     description:
       name: go_router
-      sha256: f02fd7d2a4dc512fec615529824fdd217fecb3a3d3de68360293a551f21634b3
+      sha256: eff94d2a6fc79fa8b811dde79c7549808c2346037ee107a1121b4a644c745f2a
       url: "https://pub.dev"
     source: hosted
-    version: "14.8.1"
+    version: "17.0.1"
   graphs:
     dependency: transitive
     description:
@@ -467,10 +467,10 @@ packages:
     dependency: transitive
     description:
       name: json_annotation
-      sha256: "1ce844379ca14835a50d2f019a3099f419082cfdd231cd86a142af94dd5c6bb1"
+      sha256: "805fa86df56383000f640384b282ce0cb8431f1a7a2396de92fb66186d8c57df"
       url: "https://pub.dev"
     source: hosted
-    version: "4.9.0"
+    version: "4.10.0"
   leak_tracker:
     dependency: transitive
     description:
@@ -563,10 +563,10 @@ packages:
     dependency: transitive
     description:
       name: objective_c
-      sha256: "7fd0c4d8ac8980011753b9bdaed2bf15111365924cdeeeaeb596214ea2b03537"
+      sha256: "983c7fa1501f6dcc0cb7af4e42072e9993cb28d73604d25ebf4dab08165d997e"
       url: "https://pub.dev"
     source: hosted
-    version: "9.2.4"
+    version: "9.2.5"
   package_config:
     dependency: transitive
     description:
@@ -579,10 +579,10 @@ packages:
     dependency: "direct main"
     description:
       name: package_info_plus
-      sha256: "16eee997588c60225bda0488b6dcfac69280a6b7a3cf02c741895dd370a02968"
+      sha256: f69da0d3189a4b4ceaeb1a3defb0f329b3b352517f52bed4290f83d4f06bc08d
       url: "https://pub.dev"
     source: hosted
-    version: "8.3.1"
+    version: "9.0.0"
   package_info_plus_platform_interface:
     dependency: transitive
     description:
@@ -771,18 +771,18 @@ packages:
     dependency: "direct main"
     description:
       name: share_plus
-      sha256: fce43200aa03ea87b91ce4c3ac79f0cecd52e2a7a56c7a4185023c271fbfa6da
+      sha256: "14c8860d4de93d3a7e53af51bff479598c4e999605290756bbbe45cf65b37840"
       url: "https://pub.dev"
     source: hosted
-    version: "10.1.4"
+    version: "12.0.1"
   share_plus_platform_interface:
     dependency: transitive
     description:
       name: share_plus_platform_interface
-      sha256: cc012a23fc2d479854e6c80150696c4a5f5bb62cb89af4de1c505cf78d0a5d0b
+      sha256: "88023e53a13429bd65d8e85e11a9b484f49d4c190abbd96c7932b74d6927cc9a"
       url: "https://pub.dev"
     source: hosted
-    version: "5.0.2"
+    version: "6.1.0"
   shelf:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -54,7 +54,7 @@ dependencies:
   flutter_riverpod: ^3.2.0
 
   # Routing
-  go_router: ^14.0.0
+  go_router: ^17.0.1
 
   # Web URL strategy
   flutter_web_plugins:
@@ -63,11 +63,11 @@ dependencies:
   # Utilities
   uuid: ^4.5.1
   intl: ^0.20.2
-  package_info_plus: ^8.0.0
+  package_info_plus: ^9.0.0
 
   # PDF export
   pdf: ^3.11.0
-  share_plus: ^10.0.0
+  share_plus: ^12.0.1
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Update go_router to v17, package_info_plus to v9, and share_plus to v12. Fix deprecated SharePlus API call to use ShareParams.