### PR TITLE
fix: add missing Android MainActivity and fix gitignore pattern

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,7 +45,7 @@ app.*.map.json
 /android/app/release
 
 # Feuillet specific - Local data directory
-feuillet/
+/feuillet/
 *.sqlite
 *.sqlite-wal
 *.sqlite-shm

--- a/android/app/src/main/kotlin/com/feuillet/app/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/feuillet/app/MainActivity.kt
@@ -1,0 +1,5 @@
+package com.feuillet.app
+
+import io.flutter.embedding.android.FlutterActivity
+
+class MainActivity: FlutterActivity()


### PR DESCRIPTION
The Android app crashed on launch with ClassNotFoundException because MainActivity.kt was missing. Additionally, the `feuillet/` gitignore pattern was inadvertently ignoring the `com/feuillet/app/` package directory — changed to `/feuillet/` to only match the top-level data dir.