### PR TITLE
fix: use push() for screen navigation so Android back button works

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -113,7 +113,7 @@ run-macos:
 
 run-android:
 	@echo "🤖 Running on Android..."
-	flutter run -d android --dart-define=GIT_HASH=$(GIT_HASH)
+	flutter run -d $(shell flutter devices | grep android | head -1 | awk -F ' • ' '{print $$2}' | xargs) --dart-define=GIT_HASH=$(GIT_HASH)
 
 # Serve web build locally
 serve-web: build-web

--- a/lib/screens/library_screen.dart
+++ b/lib/screens/library_screen.dart
@@ -207,7 +207,7 @@ class _LibraryScreenState extends ConsumerState<LibraryScreen> {
     await ref.read(databaseProvider).updateDocument(updatedDoc);
 
     if (mounted) {
-      context.go(AppRoutes.documentPath(document.id));
+      context.push(AppRoutes.documentPath(document.id));
     }
   }
 

--- a/lib/screens/setlist_detail_screen.dart
+++ b/lib/screens/setlist_detail_screen.dart
@@ -107,7 +107,7 @@ class _SetListDetailScreenState extends State<SetListDetailScreen> {
       return;
     }
 
-    context.go(AppRoutes.setlistPerformancePath(widget.setListId));
+    context.push(AppRoutes.setlistPerformancePath(widget.setListId));
   }
 
   @override
@@ -193,7 +193,7 @@ class _SetListDetailScreenState extends State<SetListDetailScreen> {
                               IconButton(
                                 icon: const Icon(Icons.visibility),
                                 onPressed: () {
-                                  context.go(AppRoutes.documentPath(doc.id));
+                                  context.push(AppRoutes.documentPath(doc.id));
                                 },
                                 tooltip: 'View',
                               ),

--- a/lib/screens/setlists_screen.dart
+++ b/lib/screens/setlists_screen.dart
@@ -80,7 +80,7 @@ class _SetListsScreenState extends ConsumerState<SetListsScreen> {
       );
 
       if (mounted) {
-        context.go(AppRoutes.setlistDetailPath(id));
+        context.push(AppRoutes.setlistDetailPath(id));
       }
     }
   }
@@ -134,7 +134,7 @@ class _SetListsScreenState extends ConsumerState<SetListsScreen> {
     }
 
     if (mounted) {
-      context.go(AppRoutes.setlistPerformancePath(setList.id));
+      context.push(AppRoutes.setlistPerformancePath(setList.id));
     }
   }
 
@@ -238,7 +238,7 @@ class _SetListsScreenState extends ConsumerState<SetListsScreen> {
                     ],
                   ),
                   onTap: () {
-                    context.go(AppRoutes.setlistDetailPath(setList.id));
+                    context.push(AppRoutes.setlistDetailPath(setList.id));
                   },
                 ),
               );


### PR DESCRIPTION
Changed context.go() to context.push() for screen-to-screen navigations. go() replaces the route stack, so the Android back button had nothing to return to and exited to the home screen. push() preserves the stack.

Also fixed make run-android to dynamically detect the connected emulator instead of using the hardcoded -d android flag.