### PR TITLE
feat: add recursive PDF scanning in subdirectories

### DIFF
--- a/android/app/src/main/kotlin/com/feuillet/app/SafMethodChannel.kt
+++ b/android/app/src/main/kotlin/com/feuillet/app/SafMethodChannel.kt
@@ -79,20 +79,29 @@ class SafMethodChannel(private val activity: MainActivity) {
                 return
             }
 
-            val pdfFiles = documentFile.listFiles()
-                .filter { it.isFile && it.name?.lowercase()?.endsWith(".pdf") == true }
-                .map { file ->
+            val pdfFiles = mutableListOf<Map<String, Any>>()
+            collectPdfFiles(documentFile, pdfFiles)
+
+            result.success(pdfFiles)
+        } catch (e: Exception) {
+            result.error("LIST_ERROR", e.message, null)
+        }
+    }
+
+    private fun collectPdfFiles(directory: DocumentFile, result: MutableList<Map<String, Any>>) {
+        for (file in directory.listFiles()) {
+            if (file.isDirectory) {
+                collectPdfFiles(file, result)
+            } else if (file.isFile && file.name?.lowercase()?.endsWith(".pdf") == true) {
+                result.add(
                     mapOf(
                         "uri" to file.uri.toString(),
                         "name" to (file.name ?: ""),
                         "size" to file.length(),
                         "lastModified" to file.lastModified()
                     )
-                }
-
-            result.success(pdfFiles)
-        } catch (e: Exception) {
-            result.error("LIST_ERROR", e.message, null)
+                )
+            }
         }
     }
 

--- a/lib/services/file_access_service.dart
+++ b/lib/services/file_access_service.dart
@@ -94,7 +94,7 @@ class FileAccessService {
     if (!await dir.exists()) return [];
 
     final files = <PdfFileInfo>[];
-    await for (final entity in dir.list()) {
+    await for (final entity in dir.list(recursive: true)) {
       if (entity is File && entity.path.toLowerCase().endsWith('.pdf')) {
         final stat = await entity.stat();
         files.add(


### PR DESCRIPTION
Enable the app to discover PDF files in subdirectories, not just at the root of the PDF directory. This applies to both local filesystem (via recursive dir.list()) and Android SAF (via new collectPdfFiles helper).