### PR TITLE
feat: add swipe gesture for page navigation on touch screens

### DIFF
--- a/lib/screens/pdf_viewer_screen.dart
+++ b/lib/screens/pdf_viewer_screen.dart
@@ -84,6 +84,22 @@ class _PdfViewerScreenState extends ConsumerState<PdfViewerScreen>
   @override
   void onZoomChanged() => _saveSettings();
 
+  @override
+  void onSwipeLeft() {
+    if (_annotationMode) return;
+    if (_canGoToNext()) {
+      _goToNextPage();
+    }
+  }
+
+  @override
+  void onSwipeRight() {
+    if (_annotationMode) return;
+    if (_canGoToPrevious()) {
+      _goToPreviousPage();
+    }
+  }
+
   Future<void> _initializePdf() async {
     try {
       final db = ref.read(databaseProvider);
@@ -612,6 +628,7 @@ class _PdfViewerScreenState extends ConsumerState<PdfViewerScreen>
       controller: _singlePageController,
       scrollDirection: Axis.horizontal,
       pageSnapping: true,
+      physics: const NeverScrollableScrollPhysics(),
       itemCount: _pdfDocument!.pagesCount,
       onPageChanged: (index) => _onPageChanged(index + 1),
       itemBuilder: (context, index) {

--- a/lib/screens/setlist_performance_screen.dart
+++ b/lib/screens/setlist_performance_screen.dart
@@ -71,6 +71,12 @@ class _SetListPerformanceScreenState extends State<SetListPerformanceScreen>
   @override
   void onZoomPanTap() => _autoHideController.toggle();
 
+  @override
+  void onSwipeLeft() => _goToNextPage();
+
+  @override
+  void onSwipeRight() => _goToPreviousPage();
+
   Future<void> _initializeDocuments() async {
     // Load the first document immediately
     await _ensureDocumentLoaded(0);

--- a/lib/widgets/performance_document_view.dart
+++ b/lib/widgets/performance_document_view.dart
@@ -295,6 +295,7 @@ class PerformanceDocumentViewState extends State<PerformanceDocumentView> {
       controller: _pageController,
       scrollDirection: Axis.horizontal,
       pageSnapping: true,
+      physics: const NeverScrollableScrollPhysics(),
       itemCount: widget.document.pageCount,
       onPageChanged: _onSinglePageChanged,
       itemBuilder: (context, index) {


### PR DESCRIPTION
- Add horizontal swipe gesture detection to ZoomPanGestureMixin for page navigation on touch screens
- At 1x zoom: swipe left = next page, swipe right = previous page (50px threshold) When zoomed in: pan within content bounds, page changes on 80px overscroll past boundary
- Wired up in both PdfViewerScreen and SetListPerformanceScreen (with cross-document navigation)
- Fixed gesture conflict: disabled PageView scroll physics to prevent competing with outer GestureDetector