### PR TITLE
feat: add sorting by file size and page count

### DIFF
--- a/lib/screens/library_screen.dart
+++ b/lib/screens/library_screen.dart
@@ -33,7 +33,7 @@ class LibraryScreen extends ConsumerStatefulWidget {
   ConsumerState<LibraryScreen> createState() => _LibraryScreenState();
 }
 
-enum LibrarySortField { dateAdded, name }
+enum LibrarySortField { dateAdded, name, fileSize, pageCount }
 
 class _LibraryScreenState extends ConsumerState<LibraryScreen> {
   bool _isGridView = true;
@@ -235,6 +235,18 @@ class _LibraryScreenState extends ConsumerState<LibraryScreen> {
           (a, b) => _sortAscending
               ? a.dateAdded.compareTo(b.dateAdded)
               : b.dateAdded.compareTo(a.dateAdded),
+        );
+      case LibrarySortField.fileSize:
+        result.sort(
+          (a, b) => _sortAscending
+              ? a.fileSize.compareTo(b.fileSize)
+              : b.fileSize.compareTo(a.fileSize),
+        );
+      case LibrarySortField.pageCount:
+        result.sort(
+          (a, b) => _sortAscending
+              ? a.pageCount.compareTo(b.pageCount)
+              : b.pageCount.compareTo(a.pageCount),
         );
     }
     return result;
@@ -843,7 +855,7 @@ class _LibraryScreenState extends ConsumerState<LibraryScreen> {
                 _sortAscending = !_sortAscending;
               } else {
                 _sortField = field;
-                // Default: A-Z for name, newest first for date
+                // Default: A-Z for name, descending for everything else
                 _sortAscending = field == LibrarySortField.name;
               }
             });
@@ -870,6 +882,36 @@ class _LibraryScreenState extends ConsumerState<LibraryScreen> {
                 children: [
                   const Expanded(child: Text('Date added')),
                   if (_sortField == LibrarySortField.dateAdded)
+                    Icon(
+                      _sortAscending
+                          ? Icons.arrow_upward
+                          : Icons.arrow_downward,
+                      size: 18,
+                    ),
+                ],
+              ),
+            ),
+            PopupMenuItem(
+              value: LibrarySortField.fileSize,
+              child: Row(
+                children: [
+                  const Expanded(child: Text('File size')),
+                  if (_sortField == LibrarySortField.fileSize)
+                    Icon(
+                      _sortAscending
+                          ? Icons.arrow_upward
+                          : Icons.arrow_downward,
+                      size: 18,
+                    ),
+                ],
+              ),
+            ),
+            PopupMenuItem(
+              value: LibrarySortField.pageCount,
+              child: Row(
+                children: [
+                  const Expanded(child: Text('Page count')),
+                  if (_sortField == LibrarySortField.pageCount)
                     Icon(
                       _sortAscending
                           ? Icons.arrow_upward

--- a/test/screens/library_screen_sort_test.dart
+++ b/test/screens/library_screen_sort_test.dart
@@ -29,6 +29,18 @@ List<Document> sortDocuments(
             ? a.dateAdded.compareTo(b.dateAdded)
             : b.dateAdded.compareTo(a.dateAdded),
       );
+    case LibrarySortField.fileSize:
+      result.sort(
+        (a, b) => sortAscending
+            ? a.fileSize.compareTo(b.fileSize)
+            : b.fileSize.compareTo(a.fileSize),
+      );
+    case LibrarySortField.pageCount:
+      result.sort(
+        (a, b) => sortAscending
+            ? a.pageCount.compareTo(b.pageCount)
+            : b.pageCount.compareTo(a.pageCount),
+      );
   }
   return result;
 }
@@ -166,6 +178,66 @@ void main() {
     });
   });
 
+  group('Library Sort - by file size', () {
+    test('ascending sorts smallest first', () {
+      final sorted = sortDocuments(
+        testDocuments,
+        sortField: LibrarySortField.fileSize,
+        sortAscending: true,
+      );
+
+      expect(sorted.map((d) => d.name).toList(), [
+        'Bach Fugue', // 512000
+        'Beethoven Sonata', // 1024000
+        'Mozart Concerto', // 2048000
+      ]);
+    });
+
+    test('descending sorts largest first', () {
+      final sorted = sortDocuments(
+        testDocuments,
+        sortField: LibrarySortField.fileSize,
+        sortAscending: false,
+      );
+
+      expect(sorted.map((d) => d.name).toList(), [
+        'Mozart Concerto', // 2048000
+        'Beethoven Sonata', // 1024000
+        'Bach Fugue', // 512000
+      ]);
+    });
+  });
+
+  group('Library Sort - by page count', () {
+    test('ascending sorts fewest pages first', () {
+      final sorted = sortDocuments(
+        testDocuments,
+        sortField: LibrarySortField.pageCount,
+        sortAscending: true,
+      );
+
+      expect(sorted.map((d) => d.name).toList(), [
+        'Bach Fugue', // 5
+        'Beethoven Sonata', // 10
+        'Mozart Concerto', // 20
+      ]);
+    });
+
+    test('descending sorts most pages first', () {
+      final sorted = sortDocuments(
+        testDocuments,
+        sortField: LibrarySortField.pageCount,
+        sortAscending: false,
+      );
+
+      expect(sorted.map((d) => d.name).toList(), [
+        'Mozart Concerto', // 20
+        'Beethoven Sonata', // 10
+        'Bach Fugue', // 5
+      ]);
+    });
+  });
+
   group('Library Sort - with search filter', () {
     test('filters then sorts by name ascending', () {
       final sorted = sortDocuments(
@@ -237,6 +309,38 @@ void main() {
 
       expect(sortField, LibrarySortField.name);
       expect(sortAscending, isTrue); // A-Z by default for name
+    });
+
+    test('switching to file size sets largest first by default', () {
+      var sortField = LibrarySortField.name;
+      var sortAscending = true;
+
+      final tappedField = LibrarySortField.fileSize;
+      if (sortField == tappedField) {
+        sortAscending = !sortAscending;
+      } else {
+        sortField = tappedField;
+        sortAscending = tappedField == LibrarySortField.name;
+      }
+
+      expect(sortField, LibrarySortField.fileSize);
+      expect(sortAscending, isFalse); // largest first by default
+    });
+
+    test('switching to page count sets most pages first by default', () {
+      var sortField = LibrarySortField.name;
+      var sortAscending = true;
+
+      final tappedField = LibrarySortField.pageCount;
+      if (sortField == tappedField) {
+        sortAscending = !sortAscending;
+      } else {
+        sortField = tappedField;
+        sortAscending = tappedField == LibrarySortField.name;
+      }
+
+      expect(sortField, LibrarySortField.pageCount);
+      expect(sortAscending, isFalse); // most pages first by default
     });
 
     test('switching to date sets newest first by default', () {


### PR DESCRIPTION
Extend LibrarySortField enum with fileSize and pageCount options. Add corresponding sort logic that defaults to largest/most pages first. Update popup menu with two new sort options and add 6 new unit tests covering all scenarios.