### PR TITLE
feat: add fuzzy search to library and document picker

### DIFF
--- a/lib/screens/library_screen.dart
+++ b/lib/screens/library_screen.dart
@@ -13,6 +13,7 @@ import '../services/pdf_export_service.dart';
 import '../services/pdf_service.dart';
 import '../services/setlist_service.dart';
 import '../services/version_service.dart';
+import '../utils/fuzzy_search.dart';
 import '../widgets/pdf_card.dart';
 import '../widgets/setlist_picker_dialog.dart';
 import '../widgets/export_pdf_dialog_web.dart'
@@ -216,38 +217,37 @@ class _LibraryScreenState extends ConsumerState<LibraryScreen> {
   }
 
   List<Document> _filterDocuments(List<Document> documents) {
-    var result = documents;
-    if (_searchQuery.isNotEmpty) {
-      result = result.where((doc) {
-        return doc.name.toLowerCase().contains(_searchQuery.toLowerCase());
-      }).toList();
-    }
-    result = List.of(result);
-    switch (_sortField) {
-      case LibrarySortField.name:
-        result.sort(
-          (a, b) => _sortAscending
-              ? a.name.toLowerCase().compareTo(b.name.toLowerCase())
-              : b.name.toLowerCase().compareTo(a.name.toLowerCase()),
-        );
-      case LibrarySortField.dateAdded:
-        result.sort(
-          (a, b) => _sortAscending
-              ? a.dateAdded.compareTo(b.dateAdded)
-              : b.dateAdded.compareTo(a.dateAdded),
-        );
-      case LibrarySortField.fileSize:
-        result.sort(
-          (a, b) => _sortAscending
-              ? a.fileSize.compareTo(b.fileSize)
-              : b.fileSize.compareTo(a.fileSize),
-        );
-      case LibrarySortField.pageCount:
-        result.sort(
-          (a, b) => _sortAscending
-              ? a.pageCount.compareTo(b.pageCount)
-              : b.pageCount.compareTo(a.pageCount),
-        );
+    var result = fuzzySearchDocuments(documents, _searchQuery);
+    // When searching, preserve fuzzy relevance ordering;
+    // when not searching, apply user-selected sort.
+    if (_searchQuery.isEmpty) {
+      result = List.of(result);
+      switch (_sortField) {
+        case LibrarySortField.name:
+          result.sort(
+            (a, b) => _sortAscending
+                ? a.name.toLowerCase().compareTo(b.name.toLowerCase())
+                : b.name.toLowerCase().compareTo(a.name.toLowerCase()),
+          );
+        case LibrarySortField.dateAdded:
+          result.sort(
+            (a, b) => _sortAscending
+                ? a.dateAdded.compareTo(b.dateAdded)
+                : b.dateAdded.compareTo(a.dateAdded),
+          );
+        case LibrarySortField.fileSize:
+          result.sort(
+            (a, b) => _sortAscending
+                ? a.fileSize.compareTo(b.fileSize)
+                : b.fileSize.compareTo(a.fileSize),
+          );
+        case LibrarySortField.pageCount:
+          result.sort(
+            (a, b) => _sortAscending
+                ? a.pageCount.compareTo(b.pageCount)
+                : b.pageCount.compareTo(a.pageCount),
+          );
+      }
     }
     return result;
   }

--- a/lib/utils/fuzzy_search.dart
+++ b/lib/utils/fuzzy_search.dart
@@ -1,0 +1,47 @@
+import 'package:fuzzy/fuzzy.dart';
+import '../models/database.dart';
+
+/// Performs fuzzy search on a list of documents by name.
+/// Returns all documents in original order when query is empty.
+/// Blends fuzzy relevance score with recency (lastOpened) for ordering.
+List<Document> fuzzySearchDocuments(
+  List<Document> documents,
+  String query, {
+  DateTime? now,
+}) {
+  if (query.isEmpty) {
+    return documents;
+  }
+
+  final fuse = Fuzzy<Document>(
+    documents,
+    options: FuzzyOptions(
+      keys: [WeightedKey(name: 'name', getter: (doc) => doc.name, weight: 1.0)],
+      threshold: 0.4,
+      tokenize: true,
+      shouldSort: true,
+    ),
+  );
+
+  final results = fuse.search(query);
+
+  // Blend fuzzy score with recency
+  final referenceTime = now ?? DateTime.now();
+  final scored = results.map((r) {
+    final recencyPenalty = _recencyPenalty(r.item.lastOpened, referenceTime);
+    final combinedScore = r.score * 0.8 + recencyPenalty * 0.2;
+    return (doc: r.item, score: combinedScore);
+  }).toList();
+
+  scored.sort((a, b) => a.score.compareTo(b.score));
+
+  return scored.map((s) => s.doc).toList();
+}
+
+/// Returns a penalty between 0.0 (recently opened) and 1.0 (never opened or old).
+double _recencyPenalty(DateTime? lastOpened, DateTime now) {
+  if (lastOpened == null) return 1.0;
+  final daysSince = now.difference(lastOpened).inDays;
+  // Normalize: 0 days = 0.0, 365+ days = 1.0
+  return (daysSince / 365).clamp(0.0, 1.0);
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -378,6 +378,14 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  fuzzy:
+    dependency: "direct main"
+    description:
+      name: fuzzy
+      sha256: af5fbd36f2f8de0663a5b562ef5ca209aea957e81a2f0e97f97475cfbed044ec
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.5.1"
   glob:
     dependency: transitive
     description:
@@ -924,6 +932,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.4.1"
+  stringr:
+    dependency: transitive
+    description:
+      name: stringr
+      sha256: bcc6e5cef07142673ff454b0fe7ca153e433646c52edf729636980e8a47bd7b7
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.2.1"
   sync_http:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -68,6 +68,7 @@ dependencies:
   uuid: ^4.5.3
   intl: ^0.20.2
   package_info_plus: ^9.0.0
+  fuzzy: ^0.5.1
 
   # PDF export
   pdf: ^3.11.0

--- a/test/utils/fuzzy_search_test.dart
+++ b/test/utils/fuzzy_search_test.dart
@@ -1,0 +1,77 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:feuillet/utils/fuzzy_search.dart';
+import 'package:feuillet/models/database.dart';
+
+Document _makeDoc(int id, String name, {DateTime? lastOpened}) {
+  return Document(
+    id: id,
+    name: name,
+    filePath: '/path/$name.pdf',
+    dateAdded: DateTime(2024, 1, 1),
+    lastOpened: lastOpened,
+    lastModified: DateTime(2024, 1, 1),
+    fileSize: 1000,
+    pageCount: 10,
+  );
+}
+
+void main() {
+  group('fuzzySearchDocuments', () {
+    final docs = [
+      _makeDoc(1, 'Bach - Cello Suite No. 1', lastOpened: DateTime(2024, 6, 1)),
+      _makeDoc(
+        2,
+        'Beethoven - Moonlight Sonata',
+        lastOpened: DateTime(2024, 1, 1),
+      ),
+      _makeDoc(3, 'Mozart - Eine Kleine Nachtmusik'),
+      _makeDoc(4, 'Debussy - Clair de Lune', lastOpened: DateTime(2024, 12, 1)),
+    ];
+
+    test('empty query returns all documents in original order', () {
+      final result = fuzzySearchDocuments(docs, '');
+      expect(result.map((d) => d.id).toList(), [1, 2, 3, 4]);
+    });
+
+    test('exact substring match returns document', () {
+      final result = fuzzySearchDocuments(docs, 'Bach');
+      expect(result.any((d) => d.name.contains('Bach')), isTrue);
+    });
+
+    test('skipped letters match (subsequence)', () {
+      // "bch" should match "Bach"
+      final result = fuzzySearchDocuments(docs, 'bch');
+      expect(result.any((d) => d.name.contains('Bach')), isTrue);
+    });
+
+    test('misspelling match (edit distance)', () {
+      // "Bethovn" should match "Beethoven"
+      final result = fuzzySearchDocuments(docs, 'Bethovn');
+      expect(result.any((d) => d.name.contains('Beethoven')), isTrue);
+    });
+
+    test('no match returns empty list', () {
+      final result = fuzzySearchDocuments(docs, 'xyzxyzxyz');
+      expect(result, isEmpty);
+    });
+
+    test('results are sorted by relevance', () {
+      // Exact match should rank higher than fuzzy match
+      final result = fuzzySearchDocuments(docs, 'Bach');
+      expect(result.length, greaterThanOrEqualTo(1));
+      expect(result.first.name.contains('Bach'), isTrue);
+    });
+
+    test('recently opened docs rank higher among similar scores', () {
+      // Debussy (lastOpened: Dec 2024) should get a recency boost over others
+      // Use a controlled "now" so recency differences are meaningful
+      final result = fuzzySearchDocuments(
+        docs,
+        'Clair',
+        now: DateTime(2024, 12, 15),
+      );
+      expect(result, isNotEmpty);
+      expect(result.first.name.contains('Debussy'), isTrue);
+    });
+  });
+}


### PR DESCRIPTION
- Replace substring search with fuzzy matching using the fuzzy package — supports skipped letters (“bch” -> “Bach”) and misspellings (“Bethovn” -> “Beethoven”)
- Blend fuzzy relevance score (80%) with document recency from lastOpened (20%) so recently-opened documents rank higher
- Add search bar to the set list document picker dialog
- Extract shared fuzzySearchDocuments() helper used by both screens