### PR TITLE
fix: restore PDF file access after app restart on macOS using securit…

### DIFF
--- a/lib/services/app_settings_service.dart
+++ b/lib/services/app_settings_service.dart
@@ -1,4 +1,6 @@
+import 'dart:io';
 import 'package:flutter/foundation.dart';
+import 'package:macos_secure_bookmarks/macos_secure_bookmarks.dart';
 import 'package:path_provider/path_provider.dart';
 import 'package:path/path.dart' as p;
 import 'database_service.dart';
@@ -7,6 +9,7 @@ import 'file_access_service.dart';
 /// Keys for app settings stored in database
 class AppSettingKeys {
   static const pdfDirectoryPath = 'pdf_directory_path';
+  static const pdfDirectoryBookmark = 'pdf_directory_bookmark';
 }
 
 /// Service for managing app-wide settings
@@ -19,6 +22,9 @@ class AppSettingsService {
 
   /// Cached PDF directory path for performance
   String? _cachedPdfPath;
+
+  /// Whether we've already resolved the bookmark this session
+  bool _bookmarkResolved = false;
 
   /// Get the configured PDF directory path, or default if not set
   Future<String> getPdfDirectoryPath() async {
@@ -37,6 +43,11 @@ class AppSettingsService {
     );
 
     if (customPath != null && customPath.isNotEmpty) {
+      // On macOS, resolve the security-scoped bookmark to regain access
+      if (Platform.isMacOS && !_bookmarkResolved) {
+        await _resolveBookmark();
+      }
+
       // Verify the directory still exists/is accessible
       if (await FileAccessService.instance.directoryExists(customPath)) {
         _cachedPdfPath = customPath;
@@ -59,12 +70,23 @@ class AppSettingsService {
   Future<void> setPdfDirectoryPath(String path) async {
     await _database.setAppSetting(AppSettingKeys.pdfDirectoryPath, path);
     _cachedPdfPath = path;
+
+    // On macOS, create a security-scoped bookmark to persist access
+    if (!kIsWeb && Platform.isMacOS) {
+      await _createBookmark(path);
+    }
   }
 
   /// Clear custom PDF directory path (revert to default)
   Future<void> clearPdfDirectoryPath() async {
+    // Stop accessing the old bookmark if any
+    if (!kIsWeb && Platform.isMacOS) {
+      await _stopAccessingBookmark();
+    }
     await _database.deleteAppSetting(AppSettingKeys.pdfDirectoryPath);
+    await _database.deleteAppSetting(AppSettingKeys.pdfDirectoryBookmark);
     _cachedPdfPath = null;
+    _bookmarkResolved = false;
   }
 
   /// Check if using a custom PDF directory
@@ -80,5 +102,66 @@ class AppSettingsService {
   /// Invalidate cached paths (call after settings change)
   void invalidateCache() {
     _cachedPdfPath = null;
+  }
+
+  /// Create and store a security-scoped bookmark for the given directory.
+  Future<void> _createBookmark(String path) async {
+    try {
+      final secureBookmarks = SecureBookmarks();
+      final bookmark = await secureBookmarks.bookmark(Directory(path));
+      await _database.setAppSetting(
+        AppSettingKeys.pdfDirectoryBookmark,
+        bookmark,
+      );
+      _bookmarkResolved = true;
+      debugPrint('AppSettingsService: Saved security-scoped bookmark');
+    } catch (e) {
+      debugPrint('AppSettingsService: Failed to create bookmark: $e');
+    }
+  }
+
+  /// Resolve a stored security-scoped bookmark to regain directory access.
+  Future<void> _resolveBookmark() async {
+    try {
+      final bookmarkData = await _database.getAppSetting(
+        AppSettingKeys.pdfDirectoryBookmark,
+      );
+      if (bookmarkData == null || bookmarkData.isEmpty) {
+        debugPrint('AppSettingsService: No bookmark stored');
+        _bookmarkResolved = true;
+        return;
+      }
+
+      final secureBookmarks = SecureBookmarks();
+      final resolved = await secureBookmarks.resolveBookmark(
+        bookmarkData,
+        isDirectory: true,
+      );
+      await secureBookmarks.startAccessingSecurityScopedResource(resolved);
+      _bookmarkResolved = true;
+      debugPrint(
+        'AppSettingsService: Resolved bookmark, access restored to ${resolved.path}',
+      );
+    } catch (e) {
+      debugPrint('AppSettingsService: Failed to resolve bookmark: $e');
+      _bookmarkResolved = true; // Don't retry on every call
+    }
+  }
+
+  /// Stop accessing the security-scoped resource.
+  Future<void> _stopAccessingBookmark() async {
+    try {
+      final customPath = await _database.getAppSetting(
+        AppSettingKeys.pdfDirectoryPath,
+      );
+      if (customPath != null && customPath.isNotEmpty) {
+        final secureBookmarks = SecureBookmarks();
+        await secureBookmarks.stopAccessingSecurityScopedResource(
+          Directory(customPath),
+        );
+      }
+    } catch (e) {
+      debugPrint('AppSettingsService: Failed to stop accessing bookmark: $e');
+    }
   }
 }

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -7,6 +7,7 @@ import Foundation
 
 import desktop_drop
 import file_picker
+import macos_secure_bookmarks
 import package_info_plus
 import pdfx
 import share_plus
@@ -15,6 +16,7 @@ import sqlite3_flutter_libs
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   DesktopDropPlugin.register(with: registry.registrar(forPlugin: "DesktopDropPlugin"))
   FilePickerPlugin.register(with: registry.registrar(forPlugin: "FilePickerPlugin"))
+  SecureBookmarksPlugin.register(with: registry.registrar(forPlugin: "SecureBookmarksPlugin"))
   FPPPackageInfoPlusPlugin.register(with: registry.registrar(forPlugin: "FPPPackageInfoPlusPlugin"))
   PdfxPlugin.register(with: registry.registrar(forPlugin: "PdfxPlugin"))
   SharePlusMacosPlugin.register(with: registry.registrar(forPlugin: "SharePlusMacosPlugin"))

--- a/macos/Runner/DebugProfile.entitlements
+++ b/macos/Runner/DebugProfile.entitlements
@@ -10,5 +10,7 @@
 	<true/>
 	<key>com.apple.security.files.user-selected.read-write</key>
 	<true/>
+	<key>com.apple.security.files.bookmarks.app-scope</key>
+	<true/>
 </dict>
 </plist>

--- a/macos/Runner/Release.entitlements
+++ b/macos/Runner/Release.entitlements
@@ -6,5 +6,7 @@
 	<true/>
 	<key>com.apple.security.files.user-selected.read-write</key>
 	<true/>
+	<key>com.apple.security.files.bookmarks.app-scope</key>
+	<true/>
 </dict>
 </plist>

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -249,6 +249,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.7.0"
+  dio:
+    dependency: transitive
+    description:
+      name: dio
+      sha256: aff32c08f92787a557dd5c0145ac91536481831a01b4648136373cddb0e64f8c
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.9.2"
+  dio_web_adapter:
+    dependency: transitive
+    description:
+      name: dio_web_adapter
+      sha256: "2f9e64323a7c3c7ef69567d5c800424a11f8337b8b228bad02524c9fb3c1f340"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.2"
   drift:
     dependency: "direct main"
     description:
@@ -527,6 +543,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.0"
+  logging_appenders:
+    dependency: transitive
+    description:
+      name: logging_appenders
+      sha256: "7fefa09636824f312432721c0bf77967ab19003116650729bd202bdf98142d70"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.4.0+1"
+  macos_secure_bookmarks:
+    dependency: "direct main"
+    description:
+      name: macos_secure_bookmarks
+      sha256: c3163875f8fd530a1654a7cf8aa426e6e208d28bf05724a1d4960e4b7d2ca1c6
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.1"
   matcher:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -76,6 +76,7 @@ dependencies:
 
   # Permissions
   permission_handler: ^12.0.0
+  macos_secure_bookmarks: ^0.2.1
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
…y-scoped bookmarks

When the user picks a custom PDF directory on macOS, the sandboxed app is granted temporary file access. However, this access is revoked after the app restarts, causing PdfDocument.openFile() to fail silently and resulting in "Failed to load document" errors. This fix creates and persists security-scoped bookmarks to the selected directory, allowing access to be restored on subsequent app launches.

Changes:
- Added macos_secure_bookmarks dependency for bookmark handling
- Added com.apple.security.files.bookmarks.app-scope entitlement (both debug/release)
- Store bookmark data in AppSettings alongside directory path
- Resolve bookmark and start accessing resource when retrieving directory path
- Clean up resources when clearing custom directory path