### PR TITLE
fix: prevent macOS app crash on quit with proper async cleanup

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,4 +1,5 @@
 import 'dart:io' show Platform;
+import 'dart:ui';
 
 import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter/material.dart';
@@ -96,45 +97,48 @@ class AppLifecycleManager extends StatefulWidget {
   State<AppLifecycleManager> createState() => _AppLifecycleManagerState();
 }
 
-class _AppLifecycleManagerState extends State<AppLifecycleManager>
-    with WidgetsBindingObserver {
+class _AppLifecycleManagerState extends State<AppLifecycleManager> {
+  late final AppLifecycleListener _lifecycleListener;
+
   @override
   void initState() {
     super.initState();
-    WidgetsBinding.instance.addObserver(this);
+    _lifecycleListener = AppLifecycleListener(
+      onExitRequested: _handleExitRequest,
+      onStateChange: _handleStateChange,
+    );
   }
 
   @override
   void dispose() {
-    WidgetsBinding.instance.removeObserver(this);
+    _lifecycleListener.dispose();
     super.dispose();
   }
 
-  @override
-  void didChangeAppLifecycleState(AppLifecycleState state) {
-    // Skip file system operations on web
+  /// Handle app exit request (desktop only) - allows async cleanup before exit.
+  Future<AppExitResponse> _handleExitRequest() async {
+    if (kIsWeb) return AppExitResponse.exit;
+
+    debugPrint('AppLifecycleManager: Exit requested, cleaning up...');
+    SyncManager.instance.dispose();
+    await FileWatcherService.instance.dispose();
+    DocumentService.instance.dispose();
+    await DatabaseService.instance.dispose();
+    debugPrint('AppLifecycleManager: Cleanup complete, exiting.');
+    return AppExitResponse.exit;
+  }
+
+  /// Handle lifecycle state changes (background/foreground).
+  void _handleStateChange(AppLifecycleState state) {
     if (kIsWeb) return;
 
     switch (state) {
       case AppLifecycleState.resumed:
-        // Restart file watching when app comes to foreground
         FileWatcherService.instance.startWatching();
-        // Rescan library for changes made while app was in background
         DocumentService.instance.scanAndSyncLibrary();
         break;
       case AppLifecycleState.paused:
-        // Stop file watching when app goes to background
-        FileWatcherService.instance.stopWatching();
-        break;
-      case AppLifecycleState.detached:
-        // App is closing - clean up all resources
-        SyncManager.instance.dispose();
-        FileWatcherService.instance.dispose();
-        DocumentService.instance.dispose();
-        DatabaseService.instance.dispose();
-        break;
       case AppLifecycleState.hidden:
-        // macOS: window minimized or hidden, stop watching to save resources
         FileWatcherService.instance.stopWatching();
         break;
       default:

--- a/lib/services/file_watcher_service.dart
+++ b/lib/services/file_watcher_service.dart
@@ -15,6 +15,8 @@ class FileWatcherService {
 
   DirectoryWatcher? _pdfDirectoryWatcher;
   FileWatcher? _databaseWatcher;
+  StreamSubscription? _pdfWatcherSubscription;
+  StreamSubscription? _databaseWatcherSubscription;
 
   final _pdfChangesController = StreamController<WatchEvent>.broadcast();
   final _databaseChangesController = StreamController<WatchEvent>.broadcast();
@@ -96,6 +98,10 @@ class FileWatcherService {
   Future<void> stopWatching() async {
     if (!_isWatching) return;
 
+    await _pdfWatcherSubscription?.cancel();
+    await _databaseWatcherSubscription?.cancel();
+    _pdfWatcherSubscription = null;
+    _databaseWatcherSubscription = null;
     _pdfDirectoryWatcher = null;
     _databaseWatcher = null;
 
@@ -117,7 +123,7 @@ class FileWatcherService {
     try {
       _pdfDirectoryWatcher = DirectoryWatcher(_pdfDirectoryPath!);
 
-      _pdfDirectoryWatcher!.events.listen(
+      _pdfWatcherSubscription = _pdfDirectoryWatcher!.events.listen(
         (event) {
           debugPrint(
             'FileWatcherService: PDF directory event: ${event.type} - ${event.path}',
@@ -163,7 +169,7 @@ class FileWatcherService {
 
       _databaseWatcher = FileWatcher(_databasePath!);
 
-      _databaseWatcher!.events.listen(
+      _databaseWatcherSubscription = _databaseWatcher!.events.listen(
         (event) {
           debugPrint('FileWatcherService: Database event: ${event.type}');
 
@@ -236,11 +242,10 @@ class FileWatcherService {
   }
 
   /// Dispose resources
-  void dispose() {
+  Future<void> dispose() async {
+    await stopWatching();
     _pdfChangesController.close();
     _databaseChangesController.close();
     _syncChangesController.close();
-    _pdfDirectoryWatcher = null;
-    _databaseWatcher = null;
   }
 }


### PR DESCRIPTION
Replace WidgetsBindingObserver.didChangeAppLifecycleState with AppLifecycleListener .onExitRequested, which properly awaits async resource cleanup (database, file watchers) before allowing app termination. Also cancel stream subscriptions from file watchers to prevent native FSEvents handlers from firing during shutdown.

Fixes "Feuillet a quitté de manière imprévue" crash when closing window or Cmd-Q.