### PR TITLE
fix: exit annotation mode when closing floating panel

### DIFF
--- a/lib/screens/document_viewer_screen.dart
+++ b/lib/screens/document_viewer_screen.dart
@@ -634,8 +634,10 @@ class _DocumentViewerScreenState extends ConsumerState<DocumentViewerScreen>
                       _loadPageAnnotations();
                       _scheduleSidecarWrite();
                     },
-                    onClose: () =>
-                        setState(() => _showFloatingLayerPanel = false),
+                    onClose: () => setState(() {
+                      _showFloatingLayerPanel = false;
+                      _annotationMode = false;
+                    }),
                     onDrag: (delta) => _updateLayerPanelPosition(delta),
                   ),
                 ),


### PR DESCRIPTION
Closing the annotations popup now also disables annotation mode, restoring zoom/pan, swipe navigation, and keyboard controls.