### PR TITLE
fix: resolve set list sync issues on directory change and ID stability

### DIFF
--- a/lib/models/database.dart
+++ b/lib/models/database.dart
@@ -337,6 +337,12 @@ class AppDatabase extends _$AppDatabase {
     return (delete(setListItems)..where((i) => i.id.equals(id))).go();
   }
 
+  Future<void> deleteSetListItemsBySetListId(int setListId) {
+    return (delete(setListItems)
+          ..where((i) => i.setListId.equals(setListId)))
+        .go();
+  }
+
   Future<void> updateSetListItemNotes(int itemId, String? notes) async {
     await (update(setListItems)..where((t) => t.id.equals(itemId))).write(
       SetListItemsCompanion(notes: Value(notes)),

--- a/lib/models/database.dart
+++ b/lib/models/database.dart
@@ -338,9 +338,9 @@ class AppDatabase extends _$AppDatabase {
   }
 
   Future<void> deleteSetListItemsBySetListId(int setListId) {
-    return (delete(setListItems)
-          ..where((i) => i.setListId.equals(setListId)))
-        .go();
+    return (delete(
+      setListItems,
+    )..where((i) => i.setListId.equals(setListId))).go();
   }
 
   Future<void> updateSetListItemNotes(int itemId, String? notes) async {

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -54,8 +54,7 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
       await FileWatcherService.instance.updatePdfDirectoryPath();
       await DocumentService.instance.scanAndSyncLibrary();
       // Reconcile set lists from the new directory's setlists/ folder.
-      final pdfDir =
-          await AppSettingsService.instance.getPdfDirectoryPath();
+      final pdfDir = await AppSettingsService.instance.getPdfDirectoryPath();
       await SyncManager.instance.reconcileOnStartup(
         db: DatabaseService.instance.database,
         pdfDirectoryPath: pdfDir,

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -7,7 +7,9 @@ import '../router/app_router.dart';
 import '../services/app_settings_service.dart';
 import '../services/file_access_service.dart';
 import '../services/file_watcher_service.dart';
+import '../services/database_service.dart';
 import '../services/document_service.dart';
+import '../services/sync_service.dart';
 import '../services/version_service.dart';
 import '../utils/snackbar_extension.dart';
 import '../widgets/layer_dialogs.dart';
@@ -51,6 +53,13 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
       await AppSettingsService.instance.setPdfDirectoryPath(result);
       await FileWatcherService.instance.updatePdfDirectoryPath();
       await DocumentService.instance.scanAndSyncLibrary();
+      // Reconcile set lists from the new directory's setlists/ folder.
+      final pdfDir =
+          await AppSettingsService.instance.getPdfDirectoryPath();
+      await SyncManager.instance.reconcileOnStartup(
+        db: DatabaseService.instance.database,
+        pdfDirectoryPath: pdfDir,
+      );
       await _loadCurrentSettings();
 
       if (mounted) {

--- a/lib/services/sync_service.dart
+++ b/lib/services/sync_service.dart
@@ -414,23 +414,34 @@ class SetListFile {
 /// item's relative `documentPath` and matching against `filePath` in the
 /// database. Items whose documents are not found are silently skipped.
 ///
-/// Returns the new set list ID, or `null` on failure.
+/// If a set list with the same name already exists, it is updated in-place
+/// (preserving its ID) rather than deleted and recreated.
+///
+/// Returns the set list ID, or `null` on failure.
 Future<int?> importSetListFile(
   AppDatabase db,
   SetListFile setListFile,
   String pdfDirectoryPath,
 ) async {
   try {
-    // 1. Delete existing set lists with the same name (replace semantics).
+    // 1. Find existing set list with the same name, or create a new one.
     final existing = await db.getAllSetLists();
+    int? setListId;
     for (final sl in existing) {
       if (sl.name == setListFile.name) {
-        await db.deleteSetList(sl.id);
+        // Update in-place to preserve the ID.
+        await db.updateSetList(sl.copyWith(
+          description: Value(setListFile.description),
+          modifiedAt: setListFile.modifiedAt,
+        ));
+        // Remove old items; we'll re-insert from the file.
+        await db.deleteSetListItemsBySetListId(sl.id);
+        setListId = sl.id;
+        break;
       }
     }
 
-    // 2. Create the new set list.
-    final setListId = await db.insertSetList(
+    setListId ??= await db.insertSetList(
       SetListsCompanion(
         name: Value(setListFile.name),
         description: Value(setListFile.description),
@@ -438,7 +449,7 @@ Future<int?> importSetListFile(
       ),
     );
 
-    // 3. Resolve each item's document and insert set list items.
+    // 2. Resolve each item's document and insert set list items.
     final allDocuments = await db.getAllDocuments();
     final docsByPath = {for (final d in allDocuments) d.filePath: d};
     for (final item in setListFile.items) {

--- a/lib/services/sync_service.dart
+++ b/lib/services/sync_service.dart
@@ -430,10 +430,12 @@ Future<int?> importSetListFile(
     for (final sl in existing) {
       if (sl.name == setListFile.name) {
         // Update in-place to preserve the ID.
-        await db.updateSetList(sl.copyWith(
-          description: Value(setListFile.description),
-          modifiedAt: setListFile.modifiedAt,
-        ));
+        await db.updateSetList(
+          sl.copyWith(
+            description: Value(setListFile.description),
+            modifiedAt: setListFile.modifiedAt,
+          ),
+        );
         // Remove old items; we'll re-insert from the file.
         await db.deleteSetListItemsBySetListId(sl.id);
         setListId = sl.id;

--- a/test/services/sync_service_import_test.dart
+++ b/test/services/sync_service_import_test.dart
@@ -362,7 +362,7 @@ void main() {
       expect(items[0].orderIndex, 0);
     });
 
-    test('replaces existing set list with same name', () async {
+    test('updates existing set list in-place preserving ID', () async {
       // Insert an existing set list with the same name.
       final oldId = await db.insertSetList(
         SetListsCompanion(
@@ -382,17 +382,15 @@ void main() {
         items: [SetListFileItem(documentPath: 'Bach.pdf', orderIndex: 0)],
       );
 
-      final newId = await importSetListFile(db, setListFile, pdfDir);
-      expect(newId, isNotNull);
+      final returnedId = await importSetListFile(db, setListFile, pdfDir);
 
-      // Old set list should be gone.
-      final oldSetList = await db.getSetList(oldId);
-      expect(oldSetList, isNull);
+      // ID should be preserved.
+      expect(returnedId, oldId);
 
-      // New set list should exist.
-      final newSetList = await db.getSetList(newId!);
-      expect(newSetList, isNotNull);
-      expect(newSetList!.description, 'New description');
+      // Set list should be updated in-place.
+      final setList = await db.getSetList(oldId);
+      expect(setList, isNotNull);
+      expect(setList!.description, 'New description');
     });
 
     test('handles set list with null description', () async {


### PR DESCRIPTION
Set lists now appear immediately when changing home directory by running reconciliation after scanAndSyncLibrary. importSetListFile now updates existing set lists in-place (preserving IDs) instead of delete+recreate, preventing "set list not found" errors from stale ID references.