### PR TITLE
feat: add document rename with sidecar and set list sync

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -287,6 +287,12 @@
   "label": "Label",
   "labels": "Labels",
   "clearFilters": "Clear filters",
+  "renameDocument": "Rename",
+  "renameDocumentTitle": "Rename Document",
+  "documentRenamed": "Document renamed",
+  "renameFailedAlreadyExists": "A file with that name already exists",
+  "renameFailedGeneric": "Failed to rename document",
+
   "addLabels": "Add Labels",
   "newLabelName": "New label name",
   "apply": "Apply",

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -188,6 +188,12 @@
   "label": "Étiquette",
   "labels": "Étiquettes",
   "clearFilters": "Effacer les filtres",
+  "renameDocument": "Renommer",
+  "renameDocumentTitle": "Renommer le document",
+  "documentRenamed": "Document renommé",
+  "renameFailedAlreadyExists": "Un fichier avec ce nom existe déjà",
+  "renameFailedGeneric": "Échec du renommage du document",
+
   "addLabels": "Ajouter des étiquettes",
   "newLabelName": "Nom de la nouvelle étiquette",
   "apply": "Appliquer",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -1100,6 +1100,36 @@ abstract class AppLocalizations {
   /// **'Clear filters'**
   String get clearFilters;
 
+  /// No description provided for @renameDocument.
+  ///
+  /// In en, this message translates to:
+  /// **'Rename'**
+  String get renameDocument;
+
+  /// No description provided for @renameDocumentTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Rename Document'**
+  String get renameDocumentTitle;
+
+  /// No description provided for @documentRenamed.
+  ///
+  /// In en, this message translates to:
+  /// **'Document renamed'**
+  String get documentRenamed;
+
+  /// No description provided for @renameFailedAlreadyExists.
+  ///
+  /// In en, this message translates to:
+  /// **'A file with that name already exists'**
+  String get renameFailedAlreadyExists;
+
+  /// No description provided for @renameFailedGeneric.
+  ///
+  /// In en, this message translates to:
+  /// **'Failed to rename document'**
+  String get renameFailedGeneric;
+
   /// No description provided for @addLabels.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -618,6 +618,22 @@ class AppLocalizationsEn extends AppLocalizations {
   String get clearFilters => 'Clear filters';
 
   @override
+  String get renameDocument => 'Rename';
+
+  @override
+  String get renameDocumentTitle => 'Rename Document';
+
+  @override
+  String get documentRenamed => 'Document renamed';
+
+  @override
+  String get renameFailedAlreadyExists =>
+      'A file with that name already exists';
+
+  @override
+  String get renameFailedGeneric => 'Failed to rename document';
+
+  @override
   String get addLabels => 'Add Labels';
 
   @override

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -624,6 +624,21 @@ class AppLocalizationsFr extends AppLocalizations {
   String get clearFilters => 'Effacer les filtres';
 
   @override
+  String get renameDocument => 'Renommer';
+
+  @override
+  String get renameDocumentTitle => 'Renommer le document';
+
+  @override
+  String get documentRenamed => 'Document renommé';
+
+  @override
+  String get renameFailedAlreadyExists => 'Un fichier avec ce nom existe déjà';
+
+  @override
+  String get renameFailedGeneric => 'Échec du renommage du document';
+
+  @override
   String get addLabels => 'Ajouter des étiquettes';
 
   @override

--- a/lib/screens/library_screen.dart
+++ b/lib/screens/library_screen.dart
@@ -648,6 +648,53 @@ class _LibraryScreenState extends ConsumerState<LibraryScreen> {
     );
   }
 
+  Future<void> _renameDocument(Document document) async {
+    final controller = TextEditingController(text: document.name);
+    final newName = await showDialog<String>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: Text(context.l10n.renameDocumentTitle),
+        content: TextField(
+          controller: controller,
+          autofocus: true,
+          decoration: InputDecoration(labelText: context.l10n.name),
+          onSubmitted: (value) {
+            final trimmed = value.trim();
+            if (trimmed.isNotEmpty) Navigator.pop(context, trimmed);
+          },
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context),
+            child: Text(context.l10n.cancel),
+          ),
+          FilledButton(
+            onPressed: () {
+              final trimmed = controller.text.trim();
+              if (trimmed.isNotEmpty) Navigator.pop(context, trimmed);
+            },
+            child: Text(context.l10n.rename),
+          ),
+        ],
+      ),
+    );
+    controller.dispose();
+
+    if (newName == null || newName == document.name || !mounted) return;
+
+    final result = await DocumentService.instance.renameDocument(
+      document.id,
+      newName,
+    );
+
+    if (!mounted) return;
+    if (result != null) {
+      context.showSnackbar(context.l10n.documentRenamed);
+    } else {
+      context.showSnackbar(context.l10n.renameFailedGeneric);
+    }
+  }
+
   Future<void> _labelSelected() async {
     final allLabels = await LabelService.instance.getAllLabels();
     if (!mounted) return;
@@ -850,6 +897,7 @@ class _LibraryScreenState extends ConsumerState<LibraryScreen> {
                     document: doc,
                     onTap: () => _handleDocumentTap(doc),
                     onCheckboxTap: () => _handleCheckboxTap(doc),
+                    onRename: () => _renameDocument(doc),
                     isSelectionMode: _isSelectionMode || _isDragSelecting,
                     isSelected: showSelected,
                   );

--- a/lib/services/document_service.dart
+++ b/lib/services/document_service.dart
@@ -15,6 +15,7 @@ import 'database_service.dart';
 import 'file_access_service.dart';
 import 'file_watcher_service.dart';
 import 'label_service.dart';
+import 'sync_service.dart';
 
 /// Result of importing a single document file
 class DocumentImportResult {
@@ -595,6 +596,69 @@ class DocumentService {
     } catch (e, stackTrace) {
       debugPrint('DocumentService: Error scanning library: $e');
       debugPrint(stackTrace.toString());
+    }
+  }
+
+  /// Rename a document: renames the file on disk, its sidecar, updates set list
+  /// JSON files, and updates the database record.
+  ///
+  /// [newName] is the display name without extension.
+  /// Returns the new file path, or `null` on failure.
+  Future<String?> renameDocument(int documentId, String newName) async {
+    try {
+      final doc = await _database.getDocument(documentId);
+      if (doc == null) return null;
+      if (doc.filePath.startsWith('web://')) return null;
+
+      final fileAccess = FileAccessService.instance;
+      final oldPath = doc.filePath;
+      final dir = p.dirname(oldPath);
+      final ext = p.extension(oldPath);
+      final newPath = p.join(dir, '$newName$ext');
+
+      if (oldPath == newPath) return oldPath;
+      if (await fileAccess.fileExists(newPath)) return null;
+
+      final syncManager = SyncManager.instance;
+
+      // 1. Rename the sidecar file if it exists.
+      final oldSidecar = sidecarFileName(oldPath);
+      final newSidecar = sidecarFileName(newPath);
+      if (await fileAccess.fileExists(oldSidecar)) {
+        await fileAccess.renameFile(oldSidecar, newSidecar);
+        syncManager.suppressPath(oldSidecar);
+        syncManager.suppressPath(newSidecar);
+      }
+
+      // 2. Rename the document file.
+      await fileAccess.renameFile(oldPath, newPath);
+      syncManager.suppressPath(oldPath);
+      syncManager.suppressPath(newPath);
+
+      // 3. Update the database.
+      await _database.updateDocument(
+        doc.copyWith(name: newName, filePath: newPath),
+      );
+
+      // 4. Rewrite all set list JSON files that reference this document.
+      final pdfDir = await FileWatcherService.instance.getPdfDirectoryPath();
+      final allSetLists = await _database.getAllSetLists();
+      for (final setList in allSetLists) {
+        final items = await _database.getSetListItems(setList.id);
+        if (items.any((item) => item.documentId == documentId)) {
+          syncManager.scheduleSetListWrite(
+            db: _database,
+            setListId: setList.id,
+            pdfDirectoryPath: pdfDir,
+          );
+        }
+      }
+
+      debugPrint('DocumentService: Renamed "${doc.name}" to "$newName"');
+      return newPath;
+    } catch (e) {
+      debugPrint('DocumentService: Error renaming document: $e');
+      return null;
     }
   }
 

--- a/lib/services/file_access_service.dart
+++ b/lib/services/file_access_service.dart
@@ -91,6 +91,12 @@ class FileAccessService {
     return FileMetadata(size: stat.size, lastModified: stat.modified);
   }
 
+  /// Rename (move) a file. Returns the new path.
+  Future<String> renameFile(String oldPath, String newPath) async {
+    await File(oldPath).rename(newPath);
+    return newPath;
+  }
+
   /// Delete a file.
   Future<void> deleteFile(String filePath) async {
     final file = File(filePath);

--- a/lib/widgets/document_card.dart
+++ b/lib/widgets/document_card.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:typed_data';
 import 'package:flutter/material.dart';
+import '../l10n/l10n_extension.dart';
 import '../models/database.dart';
 import '../services/document_service.dart';
 import '../services/label_service.dart';
@@ -11,6 +12,7 @@ class DocumentCard extends StatefulWidget {
   final VoidCallback onTap;
   final VoidCallback? onLongPress;
   final VoidCallback? onCheckboxTap;
+  final VoidCallback? onRename;
   final bool isSelectionMode;
   final bool isSelected;
 
@@ -20,6 +22,7 @@ class DocumentCard extends StatefulWidget {
     required this.onTap,
     this.onLongPress,
     this.onCheckboxTap,
+    this.onRename,
     this.isSelectionMode = false,
     this.isSelected = false,
   });
@@ -92,6 +95,32 @@ class _DocumentCardState extends State<DocumentCard> {
         });
       }
     }
+  }
+
+  void _showContextMenu(BuildContext context, Offset position) {
+    showMenu<String>(
+      context: context,
+      position: RelativeRect.fromLTRB(
+        position.dx,
+        position.dy,
+        position.dx,
+        position.dy,
+      ),
+      items: [
+        PopupMenuItem(
+          value: 'rename',
+          child: Row(
+            children: [
+              const Icon(Icons.edit, size: 20),
+              const SizedBox(width: 8),
+              Text(context.l10n.renameDocument),
+            ],
+          ),
+        ),
+      ],
+    ).then((value) {
+      if (value == 'rename') widget.onRename?.call();
+    });
   }
 
   Widget _buildThumbnailArea(BuildContext context) {
@@ -227,28 +256,33 @@ class _DocumentCardState extends State<DocumentCard> {
     return MouseRegion(
       onEnter: (_) => setState(() => _isHovered = true),
       onExit: (_) => setState(() => _isHovered = false),
-      child: Card(
-        clipBehavior: Clip.antiAlias,
-        shape: widget.isSelected
-            ? RoundedRectangleBorder(
-                borderRadius: BorderRadius.circular(12),
-                side: BorderSide(color: colorScheme.primary, width: 3),
-              )
+      child: GestureDetector(
+        onSecondaryTapUp: widget.onRename != null
+            ? (details) => _showContextMenu(context, details.globalPosition)
             : null,
-        child: InkWell(
-          onTap: widget.onTap,
-          onLongPress: widget.onLongPress,
-          child: Stack(
-            children: [
-              Column(
-                crossAxisAlignment: CrossAxisAlignment.stretch,
-                children: [
-                  Expanded(child: _buildThumbnailArea(context)),
-                  _buildInfoSection(context),
-                ],
-              ),
-              if (showCheckbox) _buildSelectionCheckbox(colorScheme),
-            ],
+        child: Card(
+          clipBehavior: Clip.antiAlias,
+          shape: widget.isSelected
+              ? RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(12),
+                  side: BorderSide(color: colorScheme.primary, width: 3),
+                )
+              : null,
+          child: InkWell(
+            onTap: widget.onTap,
+            onLongPress: widget.onLongPress,
+            child: Stack(
+              children: [
+                Column(
+                  crossAxisAlignment: CrossAxisAlignment.stretch,
+                  children: [
+                    Expanded(child: _buildThumbnailArea(context)),
+                    _buildInfoSection(context),
+                  ],
+                ),
+                if (showCheckbox) _buildSelectionCheckbox(colorScheme),
+              ],
+            ),
           ),
         ),
       ),

--- a/test/services/rename_document_test.dart
+++ b/test/services/rename_document_test.dart
@@ -90,11 +90,13 @@ void main() {
       await File(scorePath).writeAsString('fake pdf');
 
       final oldSidecar = sidecarFileName(scorePath);
-      await File(oldSidecar).writeAsString(jsonEncode({
-        'version': 1,
-        'modifiedAt': '2026-01-01T00:00:00.000Z',
-        'layers': [],
-      }));
+      await File(oldSidecar).writeAsString(
+        jsonEncode({
+          'version': 1,
+          'modifiedAt': '2026-01-01T00:00:00.000Z',
+          'layers': [],
+        }),
+      );
 
       expect(await File(oldSidecar).exists(), isTrue);
 
@@ -135,19 +137,10 @@ void main() {
         version: 1,
         modifiedAt: DateTime.utc(2026, 1, 1),
         name: 'Concert',
-        items: [
-          SetListFileItem(
-            documentPath: 'Renamed.pdf',
-            orderIndex: 0,
-          ),
-        ],
+        items: [SetListFileItem(documentPath: 'Renamed.pdf', orderIndex: 0)],
       );
 
-      final setListId = await importSetListFile(
-        db,
-        setListFile,
-        tempDir.path,
-      );
+      final setListId = await importSetListFile(db, setListFile, tempDir.path);
       expect(setListId, isNotNull);
 
       final items = await db.getSetListItems(setListId!);

--- a/test/services/rename_document_test.dart
+++ b/test/services/rename_document_test.dart
@@ -1,0 +1,158 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:drift/drift.dart' hide Column, isNotNull, isNull;
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:feuillet/models/database.dart';
+import 'package:feuillet/services/sync_service.dart';
+
+void main() {
+  late Directory tempDir;
+  late AppDatabase db;
+
+  setUp(() async {
+    tempDir = await Directory.systemTemp.createTemp('rename_doc_test_');
+    db = AppDatabase.forTesting(NativeDatabase.memory());
+  });
+
+  tearDown(() async {
+    SyncManager.resetInstance();
+    await db.close();
+    if (await tempDir.exists()) await tempDir.delete(recursive: true);
+  });
+
+  Future<int> insertDoc(String fileName, {String type = 'pdf'}) async {
+    final path = '${tempDir.path}/$fileName';
+    await File(path).writeAsString('fake content');
+    return db.insertDocument(
+      DocumentsCompanion(
+        name: Value(fileName.split('.').first),
+        filePath: Value(path),
+        lastModified: Value(DateTime.utc(2026, 1, 1)),
+        fileSize: const Value(1000),
+        pageCount: const Value(3),
+        documentType: Value(type),
+      ),
+    );
+  }
+
+  group('sidecarFileName', () {
+    test('renames sidecar when document path changes', () {
+      expect(
+        sidecarFileName('/docs/Bach - Suite 1.pdf'),
+        '/docs/Bach - Suite 1.feuillet.json',
+      );
+      expect(
+        sidecarFileName('/docs/New Name.pdf'),
+        '/docs/New Name.feuillet.json',
+      );
+    });
+  });
+
+  group('set list file path updates after rename', () {
+    test('buildSetListFile uses current filePath from DB', () async {
+      final docId = await insertDoc('Bach.pdf');
+
+      // Create a set list referencing the document.
+      final setListId = await db.insertSetList(
+        SetListsCompanion(
+          name: const Value('Concert'),
+          modifiedAt: Value(DateTime.utc(2026, 1, 1)),
+        ),
+      );
+      await db.insertSetListItem(
+        SetListItemsCompanion(
+          setListId: Value(setListId),
+          documentId: Value(docId),
+          orderIndex: const Value(0),
+        ),
+      );
+
+      // Simulate rename: update DB to new path.
+      final doc = await db.getDocument(docId);
+      final newPath = '${tempDir.path}/New Name.pdf';
+      await db.updateDocument(
+        doc!.copyWith(name: 'New Name', filePath: newPath),
+      );
+
+      // Build the set list file and verify the relative path uses the new name.
+      final setListFile = await buildSetListFile(db, setListId, tempDir.path);
+      expect(setListFile, isNotNull);
+      expect(setListFile!.items.first.documentPath, 'New Name.pdf');
+    });
+  });
+
+  group('sidecar file rename on disk', () {
+    test('sidecar file is renamed alongside document', () async {
+      // Create score file and its sidecar.
+      final scorePath = '${tempDir.path}/Bach.pdf';
+      await File(scorePath).writeAsString('fake pdf');
+
+      final oldSidecar = sidecarFileName(scorePath);
+      await File(oldSidecar).writeAsString(jsonEncode({
+        'version': 1,
+        'modifiedAt': '2026-01-01T00:00:00.000Z',
+        'layers': [],
+      }));
+
+      expect(await File(oldSidecar).exists(), isTrue);
+
+      // Simulate rename on disk.
+      final newPath = '${tempDir.path}/Renamed.pdf';
+      await File(scorePath).rename(newPath);
+      await File(oldSidecar).rename(sidecarFileName(newPath));
+
+      expect(await File(scorePath).exists(), isFalse);
+      expect(await File(newPath).exists(), isTrue);
+      expect(await File(oldSidecar).exists(), isFalse);
+      expect(await File(sidecarFileName(newPath)).exists(), isTrue);
+
+      // Verify the sidecar content is preserved.
+      final content = await File(sidecarFileName(newPath)).readAsString();
+      final json = jsonDecode(content) as Map<String, dynamic>;
+      expect(json['version'], 1);
+    });
+  });
+
+  group('set list import resolves renamed paths', () {
+    test('importSetListFile matches updated file paths', () async {
+      // Insert a document with the "new" path (post-rename).
+      final newPath = '${tempDir.path}/Renamed.pdf';
+      await File(newPath).writeAsString('fake pdf');
+      final docId = await db.insertDocument(
+        DocumentsCompanion(
+          name: const Value('Renamed'),
+          filePath: Value(newPath),
+          lastModified: Value(DateTime.utc(2026, 1, 1)),
+          fileSize: const Value(1000),
+          pageCount: const Value(3),
+        ),
+      );
+
+      // Import a set list file that references the new name.
+      final setListFile = SetListFile(
+        version: 1,
+        modifiedAt: DateTime.utc(2026, 1, 1),
+        name: 'Concert',
+        items: [
+          SetListFileItem(
+            documentPath: 'Renamed.pdf',
+            orderIndex: 0,
+          ),
+        ],
+      );
+
+      final setListId = await importSetListFile(
+        db,
+        setListFile,
+        tempDir.path,
+      );
+      expect(setListId, isNotNull);
+
+      final items = await db.getSetListItems(setListId!);
+      expect(items.length, 1);
+      expect(items.first.documentId, docId);
+    });
+  });
+}


### PR DESCRIPTION
Rename a score from the library grid (right-click context menu). The operation renames the file on disk, moves the .feuillet.json sidecar, updates the database record, and rewrites every .setlist.json that references the document. File-watcher suppression prevents feedback loops during the rename.