### PR TITLE
chore(flutter): post-Flutter 3.41 upgrade follow-ups

### DIFF
--- a/lib/screens/library_screen.dart
+++ b/lib/screens/library_screen.dart
@@ -162,6 +162,7 @@ class _LibraryScreenState extends ConsumerState<LibraryScreen> {
     messenger.showSnackBar(
       SnackBar(
         content: Text(message),
+        duration: const Duration(seconds: 6),
         backgroundColor: isAllFailures
             ? Theme.of(context).colorScheme.error
             : null,

--- a/lib/widgets/export_pdf_dialog_web.dart
+++ b/lib/widgets/export_pdf_dialog_web.dart
@@ -1,19 +1,24 @@
-// ignore: avoid_web_libraries_in_flutter, deprecated_member_use
-import 'dart:html' as html;
+import 'dart:js_interop';
 import 'dart:typed_data';
+
+import 'package:web/web.dart' as web;
 
 /// Downloads a PDF file in the browser by creating a temporary blob URL
 /// and triggering a download via an anchor element click.
 void downloadPdf(Uint8List bytes, String fileName) {
-  final blob = html.Blob([bytes], 'application/pdf');
-  final url = html.Url.createObjectUrlFromBlob(blob);
+  final blob = web.Blob(
+    [bytes.toJS].toJS,
+    web.BlobPropertyBag(type: 'application/pdf'),
+  );
+  final url = web.URL.createObjectURL(blob);
 
-  final anchor = html.AnchorElement(href: url)
-    ..setAttribute('download', fileName)
+  final anchor = web.HTMLAnchorElement()
+    ..href = url
+    ..download = fileName
     ..style.display = 'none';
 
-  html.document.body?.append(anchor);
+  web.document.body?.append(anchor);
   anchor.click();
   anchor.remove();
-  html.Url.revokeObjectUrl(url);
+  web.URL.revokeObjectURL(url);
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1170,7 +1170,7 @@ packages:
     source: hosted
     version: "1.2.1"
   web:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: web
       sha256: "868d88a33d8a87b18ffc05f9f030ba328ffefba92d6c127917a2ba740f9cfe4a"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -83,6 +83,9 @@ dependencies:
   permission_handler: ^12.0.0
   macos_secure_bookmarks: ^0.2.1
 
+  # Web platform interop (used by export_pdf_dialog_web.dart)
+  web: ^1.1.0
+
 dev_dependencies:
   flutter_test:
     sdk: flutter
@@ -120,6 +123,15 @@ flutter:
   # assets:
   #   - images/a_dot_burr.jpeg
   #   - images/a_dot_ham.jpeg
+  #
+  # Flutter 3.41+ supports a `platforms:` field on each asset entry to
+  # restrict which platforms an asset is bundled into, e.g.:
+  #   assets:
+  #     - path: images/web_only.png
+  #       platforms: [web]
+  # The web worker files (web/sqlite3.wasm, web/drift_worker.js) are NOT
+  # Flutter assets — they're served as static files alongside index.html
+  # and copied by the Makefile/CI, so `platforms:` does not apply to them.
 
   # An image asset can refer to one or more resolution-specific "variants", see
   # https://flutter.dev/to/resolution-aware-images


### PR DESCRIPTION
- Set explicit 6s duration on the import-failure SnackBar so it still auto-dismisses after the Flutter 3.41 behavior change made action-bearing SnackBars persistent.
- Migrate web PDF download from the deprecated `dart:html` to `package:web` + `dart:js_interop`; add `web: ^1.1.0` as a direct dependency.
- Document Flutter 3.41's per-asset `platforms:` field in pubspec.yaml for future use; clarify why the Drift web worker files don't qualify.