### PR TITLE
fix(ci): migrate release workflow to softprops/action-gh-release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,10 +12,6 @@ jobs:
   create-release:
     name: Create Release
     runs-on: ubuntu-latest
-    outputs:
-      upload_url: ${{ steps.create_release.outputs.upload_url }}
-      version: ${{ steps.get_version.outputs.version }}
-
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -25,13 +21,10 @@ jobs:
         run: echo "version=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
 
       - name: Create Release
-        id: create_release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: softprops/action-gh-release@v2
         with:
-          tag_name: ${{ github.ref }}
-          release_name: Feuillet v${{ steps.get_version.outputs.version }}
+          tag_name: ${{ github.ref_name }}
+          name: Feuillet v${{ steps.get_version.outputs.version }}
           body: |
             ## Feuillet v${{ steps.get_version.outputs.version }}
 
@@ -49,6 +42,7 @@ jobs:
             See [CHANGELOG.md](https://github.com/${{ github.repository }}/blob/main/CHANGELOG.md) for details.
           draft: false
           prerelease: false
+          make_latest: 'true'
 
   build-and-upload:
     name: Build and Upload Assets
@@ -60,22 +54,16 @@ jobs:
             platform: android
             build-cmd: flutter build apk --release
             artifact-path: build/app/outputs/flutter-apk/app-release.apk
-            artifact-name: app-release.apk
-            content-type: application/vnd.android.package-archive
 
           - os: macos-latest
             platform: macos
             build-cmd: flutter build macos --release
             artifact-path: Feuillet-macOS.zip
-            artifact-name: Feuillet-macOS.zip
-            content-type: application/zip
 
           - os: ubuntu-latest
             platform: web
             build-cmd: flutter build web --release
             artifact-path: Feuillet-Web.zip
-            artifact-name: Feuillet-Web.zip
-            content-type: application/zip
 
     runs-on: ${{ matrix.os }}
 
@@ -124,11 +112,7 @@ jobs:
           zip -r ../Feuillet-Web.zip web/
 
       - name: Upload Release Asset
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: softprops/action-gh-release@v2
         with:
-          upload_url: ${{ needs.create-release.outputs.upload_url }}
-          asset_path: ${{ matrix.artifact-path }}
-          asset_name: ${{ matrix.artifact-name }}
-          asset_content_type: ${{ matrix.content-type }}
+          tag_name: ${{ github.ref_name }}
+          files: ${{ matrix.artifact-path }}


### PR DESCRIPTION
## Summary
- The v0.2.0 release workflow [failed](https://github.com/vinzd/feuillet/actions/runs/25632752730) with `Cannot upload assets to an immutable release` because `actions/create-release@v1` and `actions/upload-release-asset@v1` are archived and incompatible with GitHub's immutable-by-default releases.
- Replaced both with `softprops/action-gh-release@v2`, which creates the release and accepts asset uploads via `files:` (appending when re-run on the same tag).

## Test plan
- [ ] CI passes on this PR
- [ ] After merge: cut a v0.2.1 tag and verify all three artifacts (Android APK, macOS zip, Web zip) attach to the release