### PR TITLE
release: 0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to Feuillet will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.1] - 2026-05-10
+
+### Fixed
+- Release workflow: migrate from archived `actions/create-release@v1` and `actions/upload-release-asset@v1` to `softprops/action-gh-release@v2` so artifacts upload correctly to immutable releases
+
 ## [0.2.0] - 2026-05-10
 
 ### Added
@@ -31,5 +36,6 @@ First stable release of Feuillet — a local-first sheet music reader.
 - Set list management for organizing performances
 - Cross-device sync via sidecar files (works with Syncthing, Dropbox, etc.)
 
+[0.2.1]: https://github.com/vinzd/feuillet/releases/tag/v0.2.1
 [0.2.0]: https://github.com/vinzd/feuillet/releases/tag/v0.2.0
 [0.1.0]: https://github.com/vinzd/feuillet/releases/tag/v0.1.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 0.2.0
+version: 0.2.1
 
 environment:
   sdk: ^3.11.5


### PR DESCRIPTION
## Summary
- Bump version to 0.2.1 in `pubspec.yaml`
- Add `[0.2.1]` section to `CHANGELOG.md` documenting the release workflow migration to `softprops/action-gh-release@v2`

This is a CI-only patch release to validate the fixed release workflow (#120) end-to-end. No user-facing changes.

## Test plan
- [ ] Merge to `main`
- [ ] Tag `v0.2.1` on `main` and push to trigger the release workflow
- [ ] Verify Android APK, macOS `.app`, and web bundle attach to the GitHub release