### PR TITLE
fix(ci): use draft-then-publish flow for releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
         id: get_version
         run: echo "version=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
 
-      - name: Create Release
+      - name: Create Draft Release
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ github.ref_name }}
@@ -40,9 +40,8 @@ jobs:
 
             ### Changes
             See [CHANGELOG.md](https://github.com/${{ github.repository }}/blob/main/CHANGELOG.md) for details.
-          draft: false
+          draft: true
           prerelease: false
-          make_latest: 'true'
 
   build-and-upload:
     name: Build and Upload Assets
@@ -115,4 +114,18 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ github.ref_name }}
+          draft: true
           files: ${{ matrix.artifact-path }}
+
+  publish-release:
+    name: Publish Release
+    needs: build-and-upload
+    runs-on: ubuntu-latest
+    steps:
+      - name: Publish Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.ref_name }}
+          draft: false
+          prerelease: false
+          make_latest: 'true'


### PR DESCRIPTION
## Summary
- The previous fix (#120) still failed on the v0.2.1 run: `Cannot upload asset to an immutable release. GitHub only allows asset uploads before a release is published`
- Switch to the GitHub-supported flow: `create-release` produces a **draft**, matrix jobs upload assets to the draft, then a new `publish-release` job flips `draft=false` to publish

## Test plan
- [ ] CI passes on this PR
- [ ] After merge: delete the existing v0.2.1 release+tag on GitHub, re-tag and push, and verify all 3 artifacts attach to a published release