### PR TITLE
release: 0.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to Feuillet will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.2] - 2026-05-10
+
+### Fixed
+- Release workflow: create the GitHub release as a draft, upload artifacts to it, then publish — required because GitHub now rejects asset uploads to published (immutable) releases
+
+(0.2.1 was skipped: its tag is permanently reserved after the failed initial release attempt.)
+
 ## [0.2.1] - 2026-05-10
 
 ### Fixed
@@ -36,6 +43,7 @@ First stable release of Feuillet — a local-first sheet music reader.
 - Set list management for organizing performances
 - Cross-device sync via sidecar files (works with Syncthing, Dropbox, etc.)
 
+[0.2.2]: https://github.com/vinzd/feuillet/releases/tag/v0.2.2
 [0.2.1]: https://github.com/vinzd/feuillet/releases/tag/v0.2.1
 [0.2.0]: https://github.com/vinzd/feuillet/releases/tag/v0.2.0
 [0.1.0]: https://github.com/vinzd/feuillet/releases/tag/v0.1.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 0.2.1
+version: 0.2.2
 
 environment:
   sdk: ^3.11.5


### PR DESCRIPTION
## Summary
- Bump version to 0.2.2 in `pubspec.yaml`
- Add `[0.2.2]` section to `CHANGELOG.md`

Skipping 0.2.1: GitHub permanently reserves the v0.2.1 tag after the failed initial release attempt, so the next usable patch is 0.2.2. No user-facing code changes — this release validates the draft → upload → publish workflow merged in #122.

## Test plan
- [ ] Merge to `main`
- [ ] Tag `v0.2.2` on `main` and push to trigger the release workflow
- [ ] Verify Android APK, macOS `.app`, and web bundle attach to the published GitHub release