### PR TITLE
debug: investigate annotation persistence issue

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -128,6 +128,15 @@
   "loading": "Loading...",
   "unknown": "Unknown",
 
+  "debugSection": "Debug",
+  "startLogging": "Start logging",
+  "stopLogging": "Stop logging",
+  "loggingActive": "Recording... ({count} entries)",
+  "@loggingActive": {
+    "placeholders": { "count": {"type": "int"} }
+  },
+  "loggingDescription": "Record debug logs for troubleshooting",
+
   "newSetList": "New Set List",
   "name": "Name",
   "descriptionOptional": "Description (optional)",

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -77,6 +77,12 @@
   "loading": "Chargement...",
   "unknown": "Inconnu",
 
+  "debugSection": "Débogage",
+  "startLogging": "Démarrer les logs",
+  "stopLogging": "Arrêter les logs",
+  "loggingActive": "Enregistrement... ({count} entrées)",
+  "loggingDescription": "Enregistrer les logs pour le diagnostic",
+
   "newSetList": "Nouvelle liste",
   "name": "Nom",
   "descriptionOptional": "Description (facultatif)",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -506,6 +506,36 @@ abstract class AppLocalizations {
   /// **'Unknown'**
   String get unknown;
 
+  /// No description provided for @debugSection.
+  ///
+  /// In en, this message translates to:
+  /// **'Debug'**
+  String get debugSection;
+
+  /// No description provided for @startLogging.
+  ///
+  /// In en, this message translates to:
+  /// **'Start logging'**
+  String get startLogging;
+
+  /// No description provided for @stopLogging.
+  ///
+  /// In en, this message translates to:
+  /// **'Stop logging'**
+  String get stopLogging;
+
+  /// No description provided for @loggingActive.
+  ///
+  /// In en, this message translates to:
+  /// **'Recording... ({count} entries)'**
+  String loggingActive(int count);
+
+  /// No description provided for @loggingDescription.
+  ///
+  /// In en, this message translates to:
+  /// **'Record debug logs for troubleshooting'**
+  String get loggingDescription;
+
   /// No description provided for @newSetList.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -287,6 +287,23 @@ class AppLocalizationsEn extends AppLocalizations {
   String get unknown => 'Unknown';
 
   @override
+  String get debugSection => 'Debug';
+
+  @override
+  String get startLogging => 'Start logging';
+
+  @override
+  String get stopLogging => 'Stop logging';
+
+  @override
+  String loggingActive(int count) {
+    return 'Recording... ($count entries)';
+  }
+
+  @override
+  String get loggingDescription => 'Record debug logs for troubleshooting';
+
+  @override
   String get newSetList => 'New Set List';
 
   @override

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -290,6 +290,23 @@ class AppLocalizationsFr extends AppLocalizations {
   String get unknown => 'Inconnu';
 
   @override
+  String get debugSection => 'Débogage';
+
+  @override
+  String get startLogging => 'Démarrer les logs';
+
+  @override
+  String get stopLogging => 'Arrêter les logs';
+
+  @override
+  String loggingActive(int count) {
+    return 'Enregistrement... ($count entrées)';
+  }
+
+  @override
+  String get loggingDescription => 'Enregistrer les logs pour le diagnostic';
+
+  @override
   String get newSetList => 'Nouvelle liste';
 
   @override

--- a/lib/screens/document_viewer_screen.dart
+++ b/lib/screens/document_viewer_screen.dart
@@ -203,6 +203,8 @@ class _DocumentViewerScreenState extends ConsumerState<DocumentViewerScreen>
 
   Future<void> _loadPageAnnotations() async {
     final spread = _getCurrentSpread();
+    final stopwatch = Stopwatch()..start();
+    debugPrint('[Viewer] _loadPageAnnotations START for page ${spread.leftPage} (docId=${_document.id})');
 
     // Load annotations from all visible layers for left page
     final leftAnnotations = await _annotationService.getAllPageAnnotations(
@@ -218,6 +220,10 @@ class _DocumentViewerScreenState extends ConsumerState<DocumentViewerScreen>
         spread.rightPage! - 1,
       );
     }
+
+    stopwatch.stop();
+    final leftCounts = leftAnnotations.map((k, v) => MapEntry(k, v.length));
+    debugPrint('[Viewer] _loadPageAnnotations DONE in ${stopwatch.elapsedMilliseconds}ms: left=$leftCounts');
 
     setState(() {
       _pageAnnotations = leftAnnotations;
@@ -239,6 +245,7 @@ class _DocumentViewerScreenState extends ConsumerState<DocumentViewerScreen>
   /// Called after a stroke is completed in DrawingCanvas.
   /// Reloads annotations and schedules a sidecar write for Syncthing sync.
   void _onStrokeCompleted() {
+    debugPrint('[Viewer] _onStrokeCompleted called');
     _loadPageAnnotations();
     _scheduleSidecarWrite();
   }
@@ -422,6 +429,10 @@ class _DocumentViewerScreenState extends ConsumerState<DocumentViewerScreen>
   }
 
   Future<void> _toggleAnnotationMode() async {
+    debugPrint('[Viewer] _toggleAnnotationMode: current=$_annotationMode -> ${!_annotationMode}, selectedLayer=$_selectedLayerId');
+    final currentAnnotationCounts = _pageAnnotations.map((k, v) => MapEntry(k, v.length));
+    debugPrint('[Viewer] _toggleAnnotationMode: current _pageAnnotations=$currentAnnotationCounts');
+
     if (!_annotationMode && _selectedLayerId != null) {
       // Entering annotation mode - ensure active layer is visible
       final activeLayer = _layers.firstWhere(
@@ -976,6 +987,7 @@ class _DocumentViewerScreenState extends ConsumerState<DocumentViewerScreen>
         // Build annotation overlay if on current page with a selected layer
         Widget? annotationOverlay;
         if (isCurrentPage && _selectedLayerId != null) {
+          debugPrint('[Viewer] _buildSinglePageView: creating DrawingCanvas for page=$pageNumber layer=$_selectedLayerId enabled=$_annotationMode annotations=${_pageAnnotations.map((k, v) => MapEntry(k, v.length))}');
           annotationOverlay = DrawingCanvas(
             key: ValueKey('$_selectedLayerId-$pageNumber'),
             layerId: _selectedLayerId!,

--- a/lib/screens/document_viewer_screen.dart
+++ b/lib/screens/document_viewer_screen.dart
@@ -204,7 +204,9 @@ class _DocumentViewerScreenState extends ConsumerState<DocumentViewerScreen>
   Future<void> _loadPageAnnotations() async {
     final spread = _getCurrentSpread();
     final stopwatch = Stopwatch()..start();
-    debugPrint('[Viewer] _loadPageAnnotations START for page ${spread.leftPage} (docId=${_document.id})');
+    debugPrint(
+      '[Viewer] _loadPageAnnotations START for page ${spread.leftPage} (docId=${_document.id})',
+    );
 
     // Load annotations from all visible layers for left page
     final leftAnnotations = await _annotationService.getAllPageAnnotations(
@@ -223,14 +225,18 @@ class _DocumentViewerScreenState extends ConsumerState<DocumentViewerScreen>
 
     stopwatch.stop();
     final leftCounts = leftAnnotations.map((k, v) => MapEntry(k, v.length));
-    debugPrint('[Viewer] _loadPageAnnotations DONE in ${stopwatch.elapsedMilliseconds}ms: left=$leftCounts');
+    debugPrint(
+      '[Viewer] _loadPageAnnotations DONE in ${stopwatch.elapsedMilliseconds}ms: left=$leftCounts',
+    );
 
     // Detect stale layer IDs (e.g. after a sidecar reimport replaced layers).
     // _loadLayers re-fetches from DB and updates _selectedLayerId if stale.
     final oldSelectedLayer = _selectedLayerId;
     await _loadLayers();
     if (_selectedLayerId != oldSelectedLayer) {
-      debugPrint('[Viewer] _loadPageAnnotations: stale layer detected $oldSelectedLayer -> $_selectedLayerId');
+      debugPrint(
+        '[Viewer] _loadPageAnnotations: stale layer detected $oldSelectedLayer -> $_selectedLayerId',
+      );
     }
 
     setState(() {
@@ -437,9 +443,15 @@ class _DocumentViewerScreenState extends ConsumerState<DocumentViewerScreen>
   }
 
   Future<void> _toggleAnnotationMode() async {
-    debugPrint('[Viewer] _toggleAnnotationMode: current=$_annotationMode -> ${!_annotationMode}, selectedLayer=$_selectedLayerId');
-    final currentAnnotationCounts = _pageAnnotations.map((k, v) => MapEntry(k, v.length));
-    debugPrint('[Viewer] _toggleAnnotationMode: current _pageAnnotations=$currentAnnotationCounts');
+    debugPrint(
+      '[Viewer] _toggleAnnotationMode: current=$_annotationMode -> ${!_annotationMode}, selectedLayer=$_selectedLayerId',
+    );
+    final currentAnnotationCounts = _pageAnnotations.map(
+      (k, v) => MapEntry(k, v.length),
+    );
+    debugPrint(
+      '[Viewer] _toggleAnnotationMode: current _pageAnnotations=$currentAnnotationCounts',
+    );
 
     if (!_annotationMode && _selectedLayerId != null) {
       // Entering annotation mode - ensure active layer is visible
@@ -995,7 +1007,9 @@ class _DocumentViewerScreenState extends ConsumerState<DocumentViewerScreen>
         // Build annotation overlay if on current page with a selected layer
         Widget? annotationOverlay;
         if (isCurrentPage && _selectedLayerId != null) {
-          debugPrint('[Viewer] _buildSinglePageView: creating DrawingCanvas for page=$pageNumber layer=$_selectedLayerId enabled=$_annotationMode annotations=${_pageAnnotations.map((k, v) => MapEntry(k, v.length))}');
+          debugPrint(
+            '[Viewer] _buildSinglePageView: creating DrawingCanvas for page=$pageNumber layer=$_selectedLayerId enabled=$_annotationMode annotations=${_pageAnnotations.map((k, v) => MapEntry(k, v.length))}',
+          );
           annotationOverlay = DrawingCanvas(
             key: ValueKey('$_selectedLayerId-$pageNumber'),
             layerId: _selectedLayerId!,

--- a/lib/screens/document_viewer_screen.dart
+++ b/lib/screens/document_viewer_screen.dart
@@ -225,6 +225,14 @@ class _DocumentViewerScreenState extends ConsumerState<DocumentViewerScreen>
     final leftCounts = leftAnnotations.map((k, v) => MapEntry(k, v.length));
     debugPrint('[Viewer] _loadPageAnnotations DONE in ${stopwatch.elapsedMilliseconds}ms: left=$leftCounts');
 
+    // Detect stale layer IDs (e.g. after a sidecar reimport replaced layers).
+    // _loadLayers re-fetches from DB and updates _selectedLayerId if stale.
+    final oldSelectedLayer = _selectedLayerId;
+    await _loadLayers();
+    if (_selectedLayerId != oldSelectedLayer) {
+      debugPrint('[Viewer] _loadPageAnnotations: stale layer detected $oldSelectedLayer -> $_selectedLayerId');
+    }
+
     setState(() {
       _pageAnnotations = leftAnnotations;
       _rightPageAnnotations = rightAnnotations;

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -46,10 +46,9 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
   void _startLogRefreshIfNeeded() {
     _logRefreshTimer?.cancel();
     if (LogRecorderService.instance.isRecording) {
-      _logRefreshTimer = Timer.periodic(
-        const Duration(seconds: 2),
-        (_) { if (mounted) setState(() {}); },
-      );
+      _logRefreshTimer = Timer.periodic(const Duration(seconds: 2), (_) {
+        if (mounted) setState(() {});
+      });
     }
   }
 
@@ -226,12 +225,14 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
         isRecording ? Icons.stop_circle : Icons.bug_report,
         color: isRecording ? Colors.red : null,
       ),
-      title: Text(isRecording
-          ? context.l10n.stopLogging
-          : context.l10n.startLogging),
-      subtitle: Text(isRecording
-          ? context.l10n.loggingActive(recorder.entryCount)
-          : context.l10n.loggingDescription),
+      title: Text(
+        isRecording ? context.l10n.stopLogging : context.l10n.startLogging,
+      ),
+      subtitle: Text(
+        isRecording
+            ? context.l10n.loggingActive(recorder.entryCount)
+            : context.l10n.loggingDescription,
+      ),
       trailing: Switch(
         value: isRecording,
         onChanged: (_) => _toggleLogRecording(),

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -10,6 +11,7 @@ import '../services/file_watcher_service.dart';
 import '../services/database_service.dart';
 import '../services/document_service.dart';
 import '../services/sync_service.dart';
+import '../services/log_recorder_service.dart';
 import '../services/version_service.dart';
 import '../utils/snackbar_extension.dart';
 import '../widgets/layer_dialogs.dart';
@@ -26,11 +28,29 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
   bool _isLoading = false;
   String? _currentPath;
   bool _isCustomPath = false;
+  Timer? _logRefreshTimer;
 
   @override
   void initState() {
     super.initState();
     _loadCurrentSettings();
+    _startLogRefreshIfNeeded();
+  }
+
+  @override
+  void dispose() {
+    _logRefreshTimer?.cancel();
+    super.dispose();
+  }
+
+  void _startLogRefreshIfNeeded() {
+    _logRefreshTimer?.cancel();
+    if (LogRecorderService.instance.isRecording) {
+      _logRefreshTimer = Timer.periodic(
+        const Duration(seconds: 2),
+        (_) { if (mounted) setState(() {}); },
+      );
+    }
   }
 
   Future<void> _loadCurrentSettings() async {
@@ -186,9 +206,49 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
                     error: (error, stack) => Text(context.l10n.unknown),
                   ),
                 ),
+
+                const Divider(),
+
+                // Debug Section
+                _buildSectionHeader(context.l10n.debugSection),
+                _buildLogRecorderTile(),
               ],
             ),
     );
+  }
+
+  Widget _buildLogRecorderTile() {
+    final recorder = LogRecorderService.instance;
+    final isRecording = recorder.isRecording;
+
+    return ListTile(
+      leading: Icon(
+        isRecording ? Icons.stop_circle : Icons.bug_report,
+        color: isRecording ? Colors.red : null,
+      ),
+      title: Text(isRecording
+          ? context.l10n.stopLogging
+          : context.l10n.startLogging),
+      subtitle: Text(isRecording
+          ? context.l10n.loggingActive(recorder.entryCount)
+          : context.l10n.loggingDescription),
+      trailing: Switch(
+        value: isRecording,
+        onChanged: (_) => _toggleLogRecording(),
+      ),
+      onTap: _toggleLogRecording,
+    );
+  }
+
+  Future<void> _toggleLogRecording() async {
+    final recorder = LogRecorderService.instance;
+    if (recorder.isRecording) {
+      await recorder.stopAndShare();
+    } else {
+      recorder.start();
+    }
+    _startLogRefreshIfNeeded();
+    setState(() {});
   }
 
   Widget _buildSectionHeader(String title) {

--- a/lib/services/annotation_service.dart
+++ b/lib/services/annotation_service.dart
@@ -125,7 +125,8 @@ class AnnotationService {
   }) async {
     final data = jsonEncode(stroke.toJson());
 
-    return await _database.insertAnnotation(
+    debugPrint('[AnnotationService] saveAnnotation START layerId=$layerId page=$pageNumber type=${stroke.type} points=${stroke.points.length}');
+    final id = await _database.insertAnnotation(
       AnnotationsCompanion(
         layerId: drift.Value(layerId),
         pageNumber: drift.Value(pageNumber),
@@ -133,6 +134,8 @@ class AnnotationService {
         data: drift.Value(data),
       ),
     );
+    debugPrint('[AnnotationService] saveAnnotation DONE id=$id');
+    return id;
   }
 
   /// Delete an annotation
@@ -154,9 +157,13 @@ class AnnotationService {
         if (annotations.isNotEmpty) {
           result[layer.id] = annotations;
         }
+        debugPrint('[AnnotationService] getAllPageAnnotations layer=${layer.id} (visible=${layer.isVisible}) page=$pageNumber -> ${annotations.length} strokes');
+      } else {
+        debugPrint('[AnnotationService] getAllPageAnnotations layer=${layer.id} SKIPPED (not visible)');
       }
     }
 
+    debugPrint('[AnnotationService] getAllPageAnnotations docId=$documentId page=$pageNumber TOTAL: ${result.map((k, v) => MapEntry(k, v.length))}');
     return result;
   }
 }

--- a/lib/services/annotation_service.dart
+++ b/lib/services/annotation_service.dart
@@ -125,7 +125,9 @@ class AnnotationService {
   }) async {
     final data = jsonEncode(stroke.toJson());
 
-    debugPrint('[AnnotationService] saveAnnotation START layerId=$layerId page=$pageNumber type=${stroke.type} points=${stroke.points.length}');
+    debugPrint(
+      '[AnnotationService] saveAnnotation START layerId=$layerId page=$pageNumber type=${stroke.type} points=${stroke.points.length}',
+    );
     final id = await _database.insertAnnotation(
       AnnotationsCompanion(
         layerId: drift.Value(layerId),
@@ -157,13 +159,19 @@ class AnnotationService {
         if (annotations.isNotEmpty) {
           result[layer.id] = annotations;
         }
-        debugPrint('[AnnotationService] getAllPageAnnotations layer=${layer.id} (visible=${layer.isVisible}) page=$pageNumber -> ${annotations.length} strokes');
+        debugPrint(
+          '[AnnotationService] getAllPageAnnotations layer=${layer.id} (visible=${layer.isVisible}) page=$pageNumber -> ${annotations.length} strokes',
+        );
       } else {
-        debugPrint('[AnnotationService] getAllPageAnnotations layer=${layer.id} SKIPPED (not visible)');
+        debugPrint(
+          '[AnnotationService] getAllPageAnnotations layer=${layer.id} SKIPPED (not visible)',
+        );
       }
     }
 
-    debugPrint('[AnnotationService] getAllPageAnnotations docId=$documentId page=$pageNumber TOTAL: ${result.map((k, v) => MapEntry(k, v.length))}');
+    debugPrint(
+      '[AnnotationService] getAllPageAnnotations docId=$documentId page=$pageNumber TOTAL: ${result.map((k, v) => MapEntry(k, v.length))}',
+    );
     return result;
   }
 }

--- a/lib/services/log_recorder_service.dart
+++ b/lib/services/log_recorder_service.dart
@@ -1,0 +1,77 @@
+import 'dart:io';
+import 'package:flutter/foundation.dart';
+import 'package:path_provider/path_provider.dart';
+import 'package:share_plus/share_plus.dart';
+import 'package:path/path.dart' as path;
+
+class LogRecorderService {
+  static final LogRecorderService instance = LogRecorderService._();
+  LogRecorderService._();
+
+  bool _isRecording = false;
+  final List<String> _entries = [];
+  DateTime? _startedAt;
+  DebugPrintCallback? _originalDebugPrint;
+
+  bool get isRecording => _isRecording;
+  int get entryCount => _entries.length;
+  DateTime? get startedAt => _startedAt;
+
+  void start() {
+    if (_isRecording) return;
+
+    _entries.clear();
+    _startedAt = DateTime.now();
+    _isRecording = true;
+
+    _originalDebugPrint = debugPrint;
+    debugPrint = _recordingDebugPrint;
+
+    _record('=== Log recording started ===');
+  }
+
+  Future<void> stopAndShare() async {
+    if (!_isRecording) return;
+
+    _record('=== Log recording stopped ===');
+    _isRecording = false;
+
+    debugPrint = _originalDebugPrint!;
+    _originalDebugPrint = null;
+
+    final content = _entries.join('\n');
+    final timestamp = _startedAt!.toIso8601String().replaceAll(':', '-');
+    final fileName = 'feuillet-logs-$timestamp.txt';
+
+    if (kIsWeb) {
+      debugPrint(content);
+      return;
+    }
+
+    final tempDir = await getTemporaryDirectory();
+    final filePath = path.join(tempDir.path, fileName);
+    await File(filePath).writeAsString(content);
+
+    await SharePlus.instance.share(
+      ShareParams(
+        files: [XFile(filePath, mimeType: 'text/plain')],
+        subject: fileName,
+      ),
+    );
+  }
+
+  void _recordingDebugPrint(String? message, {int? wrapWidth}) {
+    if (message == null) return;
+    _record(message);
+    _originalDebugPrint?.call(message, wrapWidth: wrapWidth);
+  }
+
+  void _record(String message) {
+    final now = DateTime.now();
+    final ts = '${now.hour.toString().padLeft(2, '0')}:'
+        '${now.minute.toString().padLeft(2, '0')}:'
+        '${now.second.toString().padLeft(2, '0')}.'
+        '${now.millisecond.toString().padLeft(3, '0')}';
+    _entries.add('[$ts] $message');
+  }
+}

--- a/lib/services/log_recorder_service.dart
+++ b/lib/services/log_recorder_service.dart
@@ -68,7 +68,8 @@ class LogRecorderService {
 
   void _record(String message) {
     final now = DateTime.now();
-    final ts = '${now.hour.toString().padLeft(2, '0')}:'
+    final ts =
+        '${now.hour.toString().padLeft(2, '0')}:'
         '${now.minute.toString().padLeft(2, '0')}:'
         '${now.second.toString().padLeft(2, '0')}.'
         '${now.millisecond.toString().padLeft(3, '0')}';

--- a/lib/services/sync_service.dart
+++ b/lib/services/sync_service.dart
@@ -790,6 +790,20 @@ class SyncManager {
       return;
     }
 
+    // Only import if sidecar is newer than DB (same guard as reconcileOnStartup)
+    final latestDbModified = await _latestAnnotationModifiedAt(
+      db,
+      matchingDoc.id,
+    );
+    if (latestDbModified != null &&
+        !sidecar.modifiedAt.isAfter(latestDbModified)) {
+      debugPrint(
+        'SyncManager: skipping sidecar for ${matchingDoc.name} '
+        '(disk=${sidecar.modifiedAt}, db=$latestDbModified)',
+      );
+      return;
+    }
+
     await importAnnotationSidecar(db, matchingDoc.id, sidecar);
     debugPrint('SyncManager: imported sidecar for ${matchingDoc.name}');
   }

--- a/lib/widgets/drawing_canvas.dart
+++ b/lib/widgets/drawing_canvas.dart
@@ -37,12 +37,16 @@ class _DrawingCanvasState extends State<DrawingCanvas> {
   @override
   void initState() {
     super.initState();
-    debugPrint('[DrawingCanvas] initState layer=${widget.layerId} page=${widget.pageNumber} enabled=${widget.isEnabled}');
+    debugPrint(
+      '[DrawingCanvas] initState layer=${widget.layerId} page=${widget.pageNumber} enabled=${widget.isEnabled}',
+    );
   }
 
   @override
   void dispose() {
-    debugPrint('[DrawingCanvas] dispose layer=${widget.layerId} page=${widget.pageNumber} sessionStrokes=${_currentSessionStrokes.length}');
+    debugPrint(
+      '[DrawingCanvas] dispose layer=${widget.layerId} page=${widget.pageNumber} sessionStrokes=${_currentSessionStrokes.length}',
+    );
     super.dispose();
   }
 
@@ -52,17 +56,27 @@ class _DrawingCanvasState extends State<DrawingCanvas> {
     // Clear session strokes when layer or page changes to avoid stale annotations
     if (oldWidget.layerId != widget.layerId ||
         oldWidget.pageNumber != widget.pageNumber) {
-      debugPrint('[DrawingCanvas] didUpdateWidget CLEARING session strokes (layer ${oldWidget.layerId}->${widget.layerId}, page ${oldWidget.pageNumber}->${widget.pageNumber})');
+      debugPrint(
+        '[DrawingCanvas] didUpdateWidget CLEARING session strokes (layer ${oldWidget.layerId}->${widget.layerId}, page ${oldWidget.pageNumber}->${widget.pageNumber})',
+      );
       _currentSessionStrokes.clear();
       _currentStroke = null;
     }
     if (oldWidget.isEnabled != widget.isEnabled) {
-      debugPrint('[DrawingCanvas] didUpdateWidget enabled ${oldWidget.isEnabled}->${widget.isEnabled}, sessionStrokes=${_currentSessionStrokes.length}');
+      debugPrint(
+        '[DrawingCanvas] didUpdateWidget enabled ${oldWidget.isEnabled}->${widget.isEnabled}, sessionStrokes=${_currentSessionStrokes.length}',
+      );
     }
     if (oldWidget.layerAnnotations != widget.layerAnnotations) {
-      final oldCounts = oldWidget.layerAnnotations.map((k, v) => MapEntry(k, v.length));
-      final newCounts = widget.layerAnnotations.map((k, v) => MapEntry(k, v.length));
-      debugPrint('[DrawingCanvas] didUpdateWidget layerAnnotations changed: $oldCounts -> $newCounts');
+      final oldCounts = oldWidget.layerAnnotations.map(
+        (k, v) => MapEntry(k, v.length),
+      );
+      final newCounts = widget.layerAnnotations.map(
+        (k, v) => MapEntry(k, v.length),
+      );
+      debugPrint(
+        '[DrawingCanvas] didUpdateWidget layerAnnotations changed: $oldCounts -> $newCounts',
+      );
     }
   }
 
@@ -121,7 +135,9 @@ class _DrawingCanvasState extends State<DrawingCanvas> {
       _currentStroke = null;
     });
 
-    debugPrint('[DrawingCanvas] onPointerUp: stroke completed (${stroke.type}, ${stroke.points.length} pts), sessionStrokes now=${_currentSessionStrokes.length}');
+    debugPrint(
+      '[DrawingCanvas] onPointerUp: stroke completed (${stroke.type}, ${stroke.points.length} pts), sessionStrokes now=${_currentSessionStrokes.length}',
+    );
 
     // Save the stroke to database and THEN notify completion
     _saveAndNotify(stroke);
@@ -138,10 +154,14 @@ class _DrawingCanvasState extends State<DrawingCanvas> {
         stroke: stroke,
       );
       stopwatch.stop();
-      debugPrint('[DrawingCanvas] save SUCCESS id=$id in ${stopwatch.elapsedMilliseconds}ms (layer=${widget.layerId}, page=${widget.pageNumber}, type=${stroke.type})');
+      debugPrint(
+        '[DrawingCanvas] save SUCCESS id=$id in ${stopwatch.elapsedMilliseconds}ms (layer=${widget.layerId}, page=${widget.pageNumber}, type=${stroke.type})',
+      );
     } catch (e) {
       stopwatch.stop();
-      debugPrint('[DrawingCanvas] save FAILED in ${stopwatch.elapsedMilliseconds}ms: $e');
+      debugPrint(
+        '[DrawingCanvas] save FAILED in ${stopwatch.elapsedMilliseconds}ms: $e',
+      );
     }
 
     // Notify completion AFTER save
@@ -173,10 +193,15 @@ class DrawingPainter extends CustomPainter {
   @override
   void paint(Canvas canvas, Size size) {
     // Log only when state changes (not every frame)
-    final layerHash = Object.hashAll(layerAnnotations.entries.map((e) => '${e.key}:${e.value.length}'));
-    if (currentSessionStrokes.length != _lastLoggedSessionCount || layerHash != _lastLoggedLayerHash) {
+    final layerHash = Object.hashAll(
+      layerAnnotations.entries.map((e) => '${e.key}:${e.value.length}'),
+    );
+    if (currentSessionStrokes.length != _lastLoggedSessionCount ||
+        layerHash != _lastLoggedLayerHash) {
       final layerCounts = layerAnnotations.map((k, v) => MapEntry(k, v.length));
-      debugPrint('[DrawingPainter] paint state changed: layers=$layerCounts activeLayer=$activeLayerId sessionStrokes=${currentSessionStrokes.length} currentStroke=${currentStroke != null}');
+      debugPrint(
+        '[DrawingPainter] paint state changed: layers=$layerCounts activeLayer=$activeLayerId sessionStrokes=${currentSessionStrokes.length} currentStroke=${currentStroke != null}',
+      );
       _lastLoggedSessionCount = currentSessionStrokes.length;
       _lastLoggedLayerHash = layerHash;
     }

--- a/lib/widgets/drawing_canvas.dart
+++ b/lib/widgets/drawing_canvas.dart
@@ -35,13 +35,34 @@ class _DrawingCanvasState extends State<DrawingCanvas> {
   DrawingStroke? _currentStroke;
 
   @override
+  void initState() {
+    super.initState();
+    debugPrint('[DrawingCanvas] initState layer=${widget.layerId} page=${widget.pageNumber} enabled=${widget.isEnabled}');
+  }
+
+  @override
+  void dispose() {
+    debugPrint('[DrawingCanvas] dispose layer=${widget.layerId} page=${widget.pageNumber} sessionStrokes=${_currentSessionStrokes.length}');
+    super.dispose();
+  }
+
+  @override
   void didUpdateWidget(DrawingCanvas oldWidget) {
     super.didUpdateWidget(oldWidget);
     // Clear session strokes when layer or page changes to avoid stale annotations
     if (oldWidget.layerId != widget.layerId ||
         oldWidget.pageNumber != widget.pageNumber) {
+      debugPrint('[DrawingCanvas] didUpdateWidget CLEARING session strokes (layer ${oldWidget.layerId}->${widget.layerId}, page ${oldWidget.pageNumber}->${widget.pageNumber})');
       _currentSessionStrokes.clear();
       _currentStroke = null;
+    }
+    if (oldWidget.isEnabled != widget.isEnabled) {
+      debugPrint('[DrawingCanvas] didUpdateWidget enabled ${oldWidget.isEnabled}->${widget.isEnabled}, sessionStrokes=${_currentSessionStrokes.length}');
+    }
+    if (oldWidget.layerAnnotations != widget.layerAnnotations) {
+      final oldCounts = oldWidget.layerAnnotations.map((k, v) => MapEntry(k, v.length));
+      final newCounts = widget.layerAnnotations.map((k, v) => MapEntry(k, v.length));
+      debugPrint('[DrawingCanvas] didUpdateWidget layerAnnotations changed: $oldCounts -> $newCounts');
     }
   }
 
@@ -94,33 +115,38 @@ class _DrawingCanvasState extends State<DrawingCanvas> {
   void _onPointerUp(PointerUpEvent event) {
     if (_currentStroke == null) return;
 
+    final stroke = _currentStroke!;
     setState(() {
-      _currentSessionStrokes.add(_currentStroke!);
+      _currentSessionStrokes.add(stroke);
       _currentStroke = null;
     });
 
-    // Save the stroke to database
-    _saveCurrentStroke();
+    debugPrint('[DrawingCanvas] onPointerUp: stroke completed (${stroke.type}, ${stroke.points.length} pts), sessionStrokes now=${_currentSessionStrokes.length}');
 
-    // Notify completion
-    widget.onStrokeCompleted?.call();
+    // Save the stroke to database and THEN notify completion
+    _saveAndNotify(stroke);
   }
 
-  Future<void> _saveCurrentStroke() async {
-    if (_currentSessionStrokes.isEmpty) return;
-
-    final stroke = _currentSessionStrokes.last;
+  Future<void> _saveAndNotify(DrawingStroke stroke) async {
     final annotationService = AnnotationService.instance;
+    final stopwatch = Stopwatch()..start();
 
     try {
-      await annotationService.saveAnnotation(
+      final id = await annotationService.saveAnnotation(
         layerId: widget.layerId,
         pageNumber: widget.pageNumber,
         stroke: stroke,
       );
+      stopwatch.stop();
+      debugPrint('[DrawingCanvas] save SUCCESS id=$id in ${stopwatch.elapsedMilliseconds}ms (layer=${widget.layerId}, page=${widget.pageNumber}, type=${stroke.type})');
     } catch (e) {
-      debugPrint('[DrawingCanvas] Error saving annotation: $e');
+      stopwatch.stop();
+      debugPrint('[DrawingCanvas] save FAILED in ${stopwatch.elapsedMilliseconds}ms: $e');
     }
+
+    // Notify completion AFTER save
+    debugPrint('[DrawingCanvas] notifying onStrokeCompleted');
+    widget.onStrokeCompleted?.call();
   }
 }
 
@@ -141,8 +167,20 @@ class DrawingPainter extends CustomPainter {
     this.currentStroke,
   });
 
+  static int _lastLoggedSessionCount = -1;
+  static int _lastLoggedLayerHash = -1;
+
   @override
   void paint(Canvas canvas, Size size) {
+    // Log only when state changes (not every frame)
+    final layerHash = Object.hashAll(layerAnnotations.entries.map((e) => '${e.key}:${e.value.length}'));
+    if (currentSessionStrokes.length != _lastLoggedSessionCount || layerHash != _lastLoggedLayerHash) {
+      final layerCounts = layerAnnotations.map((k, v) => MapEntry(k, v.length));
+      debugPrint('[DrawingPainter] paint state changed: layers=$layerCounts activeLayer=$activeLayerId sessionStrokes=${currentSessionStrokes.length} currentStroke=${currentStroke != null}');
+      _lastLoggedSessionCount = currentSessionStrokes.length;
+      _lastLoggedLayerHash = layerHash;
+    }
+
     // Render each layer separately so erasers only affect their own layer
     for (final entry in layerAnnotations.entries) {
       final layerId = entry.key;


### PR DESCRIPTION
## Summary
- Fix race condition in `DrawingCanvas`: DB save is now awaited before triggering the annotation reload callback
- Add diagnostic `debugPrint` logging across the annotation pipeline (DrawingCanvas lifecycle, AnnotationService save/load, DocumentViewerScreen toggle/reload)
- Add `LogRecorderService` with start/stop toggle in Settings screen — on stop, exports a timestamped `.txt` log file via the system share sheet
- Localized (EN/FR) debug section in Settings

## Test plan
- [ ] Run on macOS, open a document, go to Settings > toggle logging on
- [ ] Draw annotations, toggle annotation mode off, check if strokes persist
- [ ] Go back to Settings, toggle logging off — verify share sheet opens with log file
- [ ] Review log file for save/reload race condition evidence

🤖 Generated with [Claude Code](https://claude.com/claude-code)