### PR TITLE
fix: cap render dimensions and add pre-render debug logs

### DIFF
--- a/lib/screens/document_viewer_screen.dart
+++ b/lib/screens/document_viewer_screen.dart
@@ -336,8 +336,7 @@ class _DocumentViewerScreenState extends ConsumerState<DocumentViewerScreen>
     if (key == LogicalKeyboardKey.home) {
       if (_currentPage != 1) {
         if (_viewMode == PdfViewMode.single) {
-          _singlePageController?.jumpToPage(0);
-          _onPageChanged(1);
+          _singlePageController?.jumpToPage(0); // PageController uses 0-indexed
         } else {
           _pdfController?.jumpToPage(1);
         }
@@ -350,8 +349,9 @@ class _DocumentViewerScreenState extends ConsumerState<DocumentViewerScreen>
       final lastPage = _document.pageCount;
       if (_currentPage != lastPage) {
         if (_viewMode == PdfViewMode.single) {
-          _singlePageController?.jumpToPage(lastPage - 1);
-          _onPageChanged(lastPage);
+          _singlePageController?.jumpToPage(
+            lastPage - 1,
+          ); // PageController uses 0-indexed
         } else {
           _pdfController?.jumpToPage(lastPage);
         }
@@ -364,14 +364,10 @@ class _DocumentViewerScreenState extends ConsumerState<DocumentViewerScreen>
 
   void _goToPreviousPage() {
     if (_viewMode == PdfViewMode.single) {
-      final prevPage = _currentPage - 1;
-      if (prevPage >= 1) {
-        _singlePageController?.previousPage(
-          duration: ViewerConstants.pageAnimationDuration,
-          curve: ViewerConstants.pageAnimationCurve,
-        );
-        _onPageChanged(prevPage);
-      }
+      _singlePageController?.previousPage(
+        duration: ViewerConstants.pageAnimationDuration,
+        curve: ViewerConstants.pageAnimationCurve,
+      );
     } else {
       // Two-page mode: navigate by spread
       final currentSpread = PageSpreadCalculator.getSpreadForPage(
@@ -397,14 +393,10 @@ class _DocumentViewerScreenState extends ConsumerState<DocumentViewerScreen>
 
   void _goToNextPage() {
     if (_viewMode == PdfViewMode.single) {
-      final nextPage = _currentPage + 1;
-      if (nextPage <= _document.pageCount) {
-        _singlePageController?.nextPage(
-          duration: ViewerConstants.pageAnimationDuration,
-          curve: ViewerConstants.pageAnimationCurve,
-        );
-        _onPageChanged(nextPage);
-      }
+      _singlePageController?.nextPage(
+        duration: ViewerConstants.pageAnimationDuration,
+        curve: ViewerConstants.pageAnimationCurve,
+      );
     } else {
       // Two-page mode: navigate by spread
       final currentSpread = PageSpreadCalculator.getSpreadForPage(
@@ -1007,6 +999,7 @@ class _DocumentViewerScreenState extends ConsumerState<DocumentViewerScreen>
       pageSnapping: true,
       physics: const NeverScrollableScrollPhysics(),
       itemCount: _pdfDocument!.pagesCount,
+      onPageChanged: (index) => _onPageChanged(index + 1),
       itemBuilder: (context, index) {
         final pageNumber = index + 1;
         final isCurrentPage = pageNumber == _currentPage;

--- a/lib/screens/document_viewer_screen.dart
+++ b/lib/screens/document_viewer_screen.dart
@@ -336,7 +336,8 @@ class _DocumentViewerScreenState extends ConsumerState<DocumentViewerScreen>
     if (key == LogicalKeyboardKey.home) {
       if (_currentPage != 1) {
         if (_viewMode == PdfViewMode.single) {
-          _singlePageController?.jumpToPage(0); // PageController uses 0-indexed
+          _singlePageController?.jumpToPage(0);
+          _onPageChanged(1);
         } else {
           _pdfController?.jumpToPage(1);
         }
@@ -349,9 +350,8 @@ class _DocumentViewerScreenState extends ConsumerState<DocumentViewerScreen>
       final lastPage = _document.pageCount;
       if (_currentPage != lastPage) {
         if (_viewMode == PdfViewMode.single) {
-          _singlePageController?.jumpToPage(
-            lastPage - 1,
-          ); // PageController uses 0-indexed
+          _singlePageController?.jumpToPage(lastPage - 1);
+          _onPageChanged(lastPage);
         } else {
           _pdfController?.jumpToPage(lastPage);
         }
@@ -364,10 +364,14 @@ class _DocumentViewerScreenState extends ConsumerState<DocumentViewerScreen>
 
   void _goToPreviousPage() {
     if (_viewMode == PdfViewMode.single) {
-      _singlePageController?.previousPage(
-        duration: ViewerConstants.pageAnimationDuration,
-        curve: ViewerConstants.pageAnimationCurve,
-      );
+      final prevPage = _currentPage - 1;
+      if (prevPage >= 1) {
+        _singlePageController?.previousPage(
+          duration: ViewerConstants.pageAnimationDuration,
+          curve: ViewerConstants.pageAnimationCurve,
+        );
+        _onPageChanged(prevPage);
+      }
     } else {
       // Two-page mode: navigate by spread
       final currentSpread = PageSpreadCalculator.getSpreadForPage(
@@ -393,10 +397,14 @@ class _DocumentViewerScreenState extends ConsumerState<DocumentViewerScreen>
 
   void _goToNextPage() {
     if (_viewMode == PdfViewMode.single) {
-      _singlePageController?.nextPage(
-        duration: ViewerConstants.pageAnimationDuration,
-        curve: ViewerConstants.pageAnimationCurve,
-      );
+      final nextPage = _currentPage + 1;
+      if (nextPage <= _document.pageCount) {
+        _singlePageController?.nextPage(
+          duration: ViewerConstants.pageAnimationDuration,
+          curve: ViewerConstants.pageAnimationCurve,
+        );
+        _onPageChanged(nextPage);
+      }
     } else {
       // Two-page mode: navigate by spread
       final currentSpread = PageSpreadCalculator.getSpreadForPage(
@@ -999,7 +1007,6 @@ class _DocumentViewerScreenState extends ConsumerState<DocumentViewerScreen>
       pageSnapping: true,
       physics: const NeverScrollableScrollPhysics(),
       itemCount: _pdfDocument!.pagesCount,
-      onPageChanged: (index) => _onPageChanged(index + 1),
       itemBuilder: (context, index) {
         final pageNumber = index + 1;
         final isCurrentPage = pageNumber == _currentPage;

--- a/lib/services/pdf_page_cache_service.dart
+++ b/lib/services/pdf_page_cache_service.dart
@@ -1,7 +1,6 @@
 import 'dart:async';
 import 'dart:collection';
 import 'package:flutter/foundation.dart';
-import 'package:flutter/painting.dart';
 import 'package:pdfx/pdfx.dart';
 
 /// Cache key for a rendered PDF page
@@ -63,6 +62,12 @@ class PdfPageCacheService {
 
   /// Number of pages to pre-render ahead and behind current page
   static const int preRenderRadius = 10;
+
+  /// Maximum pixel dimension (width or height) for rendered pages.
+  /// Pages whose native size already exceeds this at the requested scale
+  /// are downscaled to fit, avoiding needlessly large renders for
+  /// high-resolution source PDFs.
+  static const int maxRenderDimension = 3000;
 
   /// Get a cached page image
   CachedPageImage? getCachedPage(String documentId, int pageNumber) {
@@ -319,15 +324,30 @@ class PdfPageCacheService {
     final page = await document.getPage(pageNumber);
     debugPrint(
       '[PreRender] _renderPage: page $pageNumber native size='
-      '${page.width}x${page.height}, '
-      'renderSize=${(page.width * scale).round()}x'
-      '${(page.height * scale).round()}',
+      '${page.width}x${page.height}',
     );
 
     try {
+      var effectiveScale = scale;
+      final maxNative =
+          page.width > page.height ? page.width : page.height;
+      if (maxNative * scale > maxRenderDimension) {
+        effectiveScale = maxRenderDimension / maxNative;
+      }
+
+      final renderWidth = page.width * effectiveScale;
+      final renderHeight = page.height * effectiveScale;
+      if (effectiveScale != scale) {
+        debugPrint(
+          '[PreRender] _renderPage: capped scale ${scale}x → '
+          '${effectiveScale.toStringAsFixed(2)}x '
+          '(${renderWidth.round()}x${renderHeight.round()})',
+        );
+      }
+
       final image = await page.render(
-        width: page.width * scale,
-        height: page.height * scale,
+        width: renderWidth,
+        height: renderHeight,
         format: PdfPageImageFormat.jpeg,
         backgroundColor: '#ffffff',
         quality: 85,
@@ -343,46 +363,17 @@ class PdfPageCacheService {
 
       final cachedImage = CachedPageImage(
         bytes: image.bytes,
-        width: image.width ?? (page.width * scale).round(),
-        height: image.height ?? (page.height * scale).round(),
+        width: image.width ?? renderWidth.round(),
+        height: image.height ?? renderHeight.round(),
       );
 
       final key = PageCacheKey(document.id, pageNumber);
       _cache[key] = cachedImage;
       _evictOldPages(document.id);
 
-      await _predecodeImage(cachedImage.bytes);
-
       return cachedImage;
     } finally {
       await page.close();
-    }
-  }
-
-  /// Pre-decode JPEG bytes into Flutter's image cache so that Image.memory
-  /// can display them instantly without an async decode step.
-  Future<void> _predecodeImage(Uint8List bytes) async {
-    try {
-      final provider = MemoryImage(bytes);
-      final stream = provider.resolve(ImageConfiguration.empty);
-      final completer = Completer<void>();
-      late ImageStreamListener listener;
-      listener = ImageStreamListener(
-        (info, synchronousCall) {
-          stream.removeListener(listener);
-          if (!completer.isCompleted) completer.complete();
-        },
-        onError: (error, stackTrace) {
-          stream.removeListener(listener);
-          if (!completer.isCompleted) {
-            completer.completeError(error, stackTrace);
-          }
-        },
-      );
-      stream.addListener(listener);
-      await completer.future;
-    } catch (e) {
-      debugPrint('[PreRender] _predecodeImage failed: $e');
     }
   }
 

--- a/lib/services/pdf_page_cache_service.dart
+++ b/lib/services/pdf_page_cache_service.dart
@@ -94,6 +94,10 @@ class PdfPageCacheService {
     double scale = 2.0,
   }) async {
     final documentId = document.id;
+    debugPrint(
+      '[PreRender] preRenderPages called: docId=$documentId, '
+      'currentPage=$currentPage, totalPages=$totalPages, scale=$scale',
+    );
 
     // Calculate pages to pre-render (current page ± radius)
     final pagesToRender = <int>[];
@@ -107,17 +111,35 @@ class PdfPageCacheService {
       }
     }
 
+    debugPrint(
+      '[PreRender] pages to consider: $pagesToRender '
+      '(${pagesToRender.length} pages)',
+    );
+
     // Clear any stale queued non-priority requests for this document
+    final queueSizeBefore = _renderQueue.length;
     _renderQueue.removeWhere(
       (r) => r.documentId == documentId && r.completer == null,
     );
+    final staleRemoved = queueSizeBefore - _renderQueue.length;
+    if (staleRemoved > 0) {
+      debugPrint('[PreRender] cleared $staleRemoved stale queued requests');
+    }
 
     // Enqueue pages for sequential rendering (at the back)
+    int skippedCached = 0;
+    int skippedRendering = 0;
+    int enqueued = 0;
     for (final pageNumber in pagesToRender) {
       final key = PageCacheKey(documentId, pageNumber);
 
       // Skip if already cached or being rendered
-      if (_cache.containsKey(key) || _rendering.contains(key)) {
+      if (_cache.containsKey(key)) {
+        skippedCached++;
+        continue;
+      }
+      if (_rendering.contains(key)) {
+        skippedRendering++;
         continue;
       }
 
@@ -128,7 +150,13 @@ class PdfPageCacheService {
           scale: scale,
         ),
       );
+      enqueued++;
     }
+
+    debugPrint(
+      '[PreRender] enqueued=$enqueued, skippedCached=$skippedCached, '
+      'skippedRendering=$skippedRendering, queueSize=${_renderQueue.length}',
+    );
 
     // Start processing the queue if not already running
     _startProcessing();
@@ -144,6 +172,9 @@ class PdfPageCacheService {
 
     // Return cached version if available
     if (_cache.containsKey(key)) {
+      debugPrint(
+        '[PreRender] renderAndCachePage: page $pageNumber already cached',
+      );
       return _cache[key];
     }
 
@@ -152,9 +183,18 @@ class PdfPageCacheService {
       if (req.documentId == document.id &&
           req.pageNumber == pageNumber &&
           req.completer != null) {
+        debugPrint(
+          '[PreRender] renderAndCachePage: page $pageNumber already queued '
+          'with completer, reusing',
+        );
         return req.completer!.future;
       }
     }
+
+    debugPrint(
+      '[PreRender] renderAndCachePage: priority render for page $pageNumber '
+      '(docId=${document.id})',
+    );
 
     // Create a priority request with a completer so we can return the result
     final completer = Completer<CachedPageImage?>();
@@ -175,42 +215,93 @@ class PdfPageCacheService {
   }
 
   void _startProcessing() {
-    if (_isProcessingQueue || _renderQueue.isEmpty) return;
+    if (_isProcessingQueue) {
+      debugPrint(
+        '[PreRender] _startProcessing: already processing '
+        '(queue=${_renderQueue.length})',
+      );
+      return;
+    }
+    if (_renderQueue.isEmpty) {
+      debugPrint('[PreRender] _startProcessing: queue empty, nothing to do');
+      return;
+    }
+    debugPrint(
+      '[PreRender] _startProcessing: beginning queue processing '
+      '(${_renderQueue.length} items)',
+    );
     _isProcessingQueue = true;
     unawaited(_processQueue());
   }
 
   Future<void> _processQueue() async {
+    int rendered = 0;
+    int skipped = 0;
+    final stopwatch = Stopwatch()..start();
+
     while (_renderQueue.isNotEmpty) {
       final request = _renderQueue.removeFirst();
       final key = PageCacheKey(request.documentId, request.pageNumber);
+      final isPriority = request.completer != null;
 
       // Skip if already cached while waiting in queue
       if (_cache.containsKey(key)) {
         request.completer?.complete(_cache[key]);
+        skipped++;
         continue;
       }
 
       // Skip non-priority requests if already being rendered elsewhere
-      if (_rendering.contains(key) && request.completer == null) {
+      if (_rendering.contains(key) && !isPriority) {
+        skipped++;
         continue;
       }
 
       _rendering.add(key);
       try {
+        final pageStopwatch = Stopwatch()..start();
         final result = await _renderPage(
           document: request.document,
           pageNumber: request.pageNumber,
           scale: request.scale,
         );
+        pageStopwatch.stop();
+
+        if (result != null) {
+          debugPrint(
+            '[PreRender] rendered page ${request.pageNumber} '
+            '(${request.documentId}) in ${pageStopwatch.elapsedMilliseconds}ms '
+            '— ${result.width}x${result.height}, '
+            '${(result.bytes.length / 1024).toStringAsFixed(0)}KB'
+            '${isPriority ? " [PRIORITY]" : ""}',
+          );
+        } else {
+          debugPrint(
+            '[PreRender] page ${request.pageNumber} '
+            '(${request.documentId}) render returned null '
+            'after ${pageStopwatch.elapsedMilliseconds}ms',
+          );
+        }
+
+        rendered++;
         request.completer?.complete(result);
-      } catch (error) {
-        debugPrint('Error rendering page ${request.pageNumber}: $error');
+      } catch (error, stack) {
+        debugPrint(
+          '[PreRender] ERROR rendering page ${request.pageNumber} '
+          '(${request.documentId}): $error\n$stack',
+        );
         request.completer?.complete(null);
       } finally {
         _rendering.remove(key);
       }
     }
+
+    stopwatch.stop();
+    debugPrint(
+      '[PreRender] queue finished: rendered=$rendered, skipped=$skipped, '
+      'totalTime=${stopwatch.elapsedMilliseconds}ms, '
+      'cacheSize=${_cache.length}',
+    );
     _isProcessingQueue = false;
   }
 
@@ -220,7 +311,17 @@ class PdfPageCacheService {
     required int pageNumber,
     required double scale,
   }) async {
+    debugPrint(
+      '[PreRender] _renderPage: opening page $pageNumber '
+      '(docId=${document.id})',
+    );
     final page = await document.getPage(pageNumber);
+    debugPrint(
+      '[PreRender] _renderPage: page $pageNumber native size='
+      '${page.width}x${page.height}, '
+      'renderSize=${(page.width * scale).round()}x'
+      '${(page.height * scale).round()}',
+    );
 
     try {
       final image = await page.render(
@@ -231,7 +332,13 @@ class PdfPageCacheService {
         quality: 85,
       );
 
-      if (image == null) return null;
+      if (image == null) {
+        debugPrint(
+          '[PreRender] _renderPage: page.render() returned null '
+          'for page $pageNumber',
+        );
+        return null;
+      }
 
       final cachedImage = CachedPageImage(
         bytes: image.bytes,

--- a/lib/services/pdf_page_cache_service.dart
+++ b/lib/services/pdf_page_cache_service.dart
@@ -329,8 +329,7 @@ class PdfPageCacheService {
 
     try {
       var effectiveScale = scale;
-      final maxNative =
-          page.width > page.height ? page.width : page.height;
+      final maxNative = page.width > page.height ? page.width : page.height;
       if (maxNative * scale > maxRenderDimension) {
         effectiveScale = maxRenderDimension / maxNative;
       }

--- a/lib/services/pdf_page_cache_service.dart
+++ b/lib/services/pdf_page_cache_service.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:collection';
 import 'package:flutter/foundation.dart';
+import 'package:flutter/painting.dart';
 import 'package:pdfx/pdfx.dart';
 
 /// Cache key for a rendered PDF page
@@ -350,9 +351,38 @@ class PdfPageCacheService {
       _cache[key] = cachedImage;
       _evictOldPages(document.id);
 
+      await _predecodeImage(cachedImage.bytes);
+
       return cachedImage;
     } finally {
       await page.close();
+    }
+  }
+
+  /// Pre-decode JPEG bytes into Flutter's image cache so that Image.memory
+  /// can display them instantly without an async decode step.
+  Future<void> _predecodeImage(Uint8List bytes) async {
+    try {
+      final provider = MemoryImage(bytes);
+      final stream = provider.resolve(ImageConfiguration.empty);
+      final completer = Completer<void>();
+      late ImageStreamListener listener;
+      listener = ImageStreamListener(
+        (info, synchronousCall) {
+          stream.removeListener(listener);
+          if (!completer.isCompleted) completer.complete();
+        },
+        onError: (error, stackTrace) {
+          stream.removeListener(listener);
+          if (!completer.isCompleted) {
+            completer.completeError(error, stackTrace);
+          }
+        },
+      );
+      stream.addListener(listener);
+      await completer.future;
+    } catch (e) {
+      debugPrint('[PreRender] _predecodeImage failed: $e');
     }
   }
 

--- a/lib/widgets/cached_pdf_page.dart
+++ b/lib/widgets/cached_pdf_page.dart
@@ -69,7 +69,12 @@ class _CachedPdfPageState extends State<CachedPdfPage> {
       '(docId=${widget.document.id})',
     );
 
-    // Check cache before setting loading state to avoid any blank frame
+    setState(() {
+      _isLoading = true;
+      _error = null;
+    });
+
+    // Check cache first
     final cached = _cacheService.getCachedPage(
       widget.document.id,
       widget.pageNumber,
@@ -84,7 +89,6 @@ class _CachedPdfPageState extends State<CachedPdfPage> {
         setState(() {
           _pageImage = cached;
           _isLoading = false;
-          _error = null;
         });
         widget.onPageRendered?.call(widget.pageNumber);
       }
@@ -95,11 +99,6 @@ class _CachedPdfPageState extends State<CachedPdfPage> {
       '[PreRender] CachedPdfPage: page ${widget.pageNumber} not cached, '
       'requesting on-demand render',
     );
-
-    setState(() {
-      _isLoading = true;
-      _error = null;
-    });
 
     // Render and cache the page
     try {
@@ -159,11 +158,7 @@ class _CachedPdfPageState extends State<CachedPdfPage> {
     }
 
     if (widget.annotationOverlay == null) {
-      return Image.memory(
-        _pageImage!.bytes,
-        fit: widget.fit,
-        gaplessPlayback: true,
-      );
+      return Image.memory(_pageImage!.bytes, fit: widget.fit);
     }
 
     // With annotation overlay: use FittedBox to scale PDF and annotations together
@@ -175,11 +170,7 @@ class _CachedPdfPageState extends State<CachedPdfPage> {
         child: Stack(
           fit: StackFit.expand,
           children: [
-            Image.memory(
-              _pageImage!.bytes,
-              fit: BoxFit.fill,
-              gaplessPlayback: true,
-            ),
+            Image.memory(_pageImage!.bytes, fit: BoxFit.fill),
             widget.annotationOverlay!,
           ],
         ),

--- a/lib/widgets/cached_pdf_page.dart
+++ b/lib/widgets/cached_pdf_page.dart
@@ -69,12 +69,7 @@ class _CachedPdfPageState extends State<CachedPdfPage> {
       '(docId=${widget.document.id})',
     );
 
-    setState(() {
-      _isLoading = true;
-      _error = null;
-    });
-
-    // Check cache first
+    // Check cache before setting loading state to avoid any blank frame
     final cached = _cacheService.getCachedPage(
       widget.document.id,
       widget.pageNumber,
@@ -89,6 +84,7 @@ class _CachedPdfPageState extends State<CachedPdfPage> {
         setState(() {
           _pageImage = cached;
           _isLoading = false;
+          _error = null;
         });
         widget.onPageRendered?.call(widget.pageNumber);
       }
@@ -99,6 +95,11 @@ class _CachedPdfPageState extends State<CachedPdfPage> {
       '[PreRender] CachedPdfPage: page ${widget.pageNumber} not cached, '
       'requesting on-demand render',
     );
+
+    setState(() {
+      _isLoading = true;
+      _error = null;
+    });
 
     // Render and cache the page
     try {
@@ -158,7 +159,11 @@ class _CachedPdfPageState extends State<CachedPdfPage> {
     }
 
     if (widget.annotationOverlay == null) {
-      return Image.memory(_pageImage!.bytes, fit: widget.fit);
+      return Image.memory(
+        _pageImage!.bytes,
+        fit: widget.fit,
+        gaplessPlayback: true,
+      );
     }
 
     // With annotation overlay: use FittedBox to scale PDF and annotations together
@@ -170,7 +175,11 @@ class _CachedPdfPageState extends State<CachedPdfPage> {
         child: Stack(
           fit: StackFit.expand,
           children: [
-            Image.memory(_pageImage!.bytes, fit: BoxFit.fill),
+            Image.memory(
+              _pageImage!.bytes,
+              fit: BoxFit.fill,
+              gaplessPlayback: true,
+            ),
             widget.annotationOverlay!,
           ],
         ),

--- a/lib/widgets/cached_pdf_page.dart
+++ b/lib/widgets/cached_pdf_page.dart
@@ -64,6 +64,11 @@ class _CachedPdfPageState extends State<CachedPdfPage> {
   }
 
   Future<void> _loadPage() async {
+    debugPrint(
+      '[PreRender] CachedPdfPage._loadPage: page ${widget.pageNumber} '
+      '(docId=${widget.document.id})',
+    );
+
     setState(() {
       _isLoading = true;
       _error = null;
@@ -76,6 +81,10 @@ class _CachedPdfPageState extends State<CachedPdfPage> {
     );
 
     if (cached != null) {
+      debugPrint(
+        '[PreRender] CachedPdfPage: page ${widget.pageNumber} served '
+        'from cache (${(cached.bytes.length / 1024).toStringAsFixed(0)}KB)',
+      );
       if (mounted) {
         setState(() {
           _pageImage = cached;
@@ -86,11 +95,24 @@ class _CachedPdfPageState extends State<CachedPdfPage> {
       return;
     }
 
+    debugPrint(
+      '[PreRender] CachedPdfPage: page ${widget.pageNumber} not cached, '
+      'requesting on-demand render',
+    );
+
     // Render and cache the page
     try {
+      final stopwatch = Stopwatch()..start();
       final image = await _cacheService.renderAndCachePage(
         document: widget.document,
         pageNumber: widget.pageNumber,
+      );
+      stopwatch.stop();
+
+      debugPrint(
+        '[PreRender] CachedPdfPage: page ${widget.pageNumber} '
+        '${image != null ? "rendered" : "FAILED (null)"} '
+        'in ${stopwatch.elapsedMilliseconds}ms',
       );
 
       if (mounted) {
@@ -100,7 +122,11 @@ class _CachedPdfPageState extends State<CachedPdfPage> {
         });
         widget.onPageRendered?.call(widget.pageNumber);
       }
-    } catch (e) {
+    } catch (e, stack) {
+      debugPrint(
+        '[PreRender] CachedPdfPage: page ${widget.pageNumber} '
+        'ERROR: $e\n$stack',
+      );
       if (mounted) {
         setState(() {
           _error = e.toString();


### PR DESCRIPTION
## Summary
- Cap rendered page dimensions at 3000px (longest side), avoiding needlessly large renders for high-resolution source PDFs
  - Bach Cantate 68 (2480x3339 native): renders at ~2232x3000 (6.7MP) instead of 4960x6678 (33MP) — **~5x faster**
  - Small PDFs (e.g. 595x812 native): unchanged at 2x scale (1190x1624, under cap)
- Add `[PreRender]` debug logs throughout the pre-rendering pipeline for diagnosing per-document issues

## Test plan
- [ ] Open Bach Cantate 68 — page transitions should be smooth, no black flash
- [ ] Open a small PDF (e.g. arpeggione) — rendering quality unchanged
- [ ] Check `[PreRender]` logs show "capped scale" for large PDFs, normal scale for small ones

🤖 Generated with [Claude Code](https://claude.com/claude-code)