### PR TITLE
fix: brightness/contrast only affects document, not background; remove modal dim

### DIFF
--- a/lib/screens/document_viewer_screen.dart
+++ b/lib/screens/document_viewer_screen.dart
@@ -559,15 +559,12 @@ class _DocumentViewerScreenState extends ConsumerState<DocumentViewerScreen>
               // PDF viewer - single or two-page mode
               // Annotations are handled internally for both modes
               Center(
-                child: ColorFiltered(
-                  colorFilter: zoomPanState.displaySettings.colorFilter,
-                  child: buildZoomPanTransform(
-                    child: _document.isImage
-                        ? _buildImageView()
-                        : _viewMode == PdfViewMode.single
-                        ? _buildSinglePageView()
-                        : _buildTwoPageView(),
-                  ),
+                child: buildZoomPanTransform(
+                  child: _document.isImage
+                      ? _buildImageView()
+                      : _viewMode == PdfViewMode.single
+                      ? _buildSinglePageView()
+                      : _buildTwoPageView(),
                 ),
               ),
 
@@ -993,7 +990,10 @@ class _DocumentViewerScreenState extends ConsumerState<DocumentViewerScreen>
     return Stack(
       fit: StackFit.expand,
       children: [
-        Image.memory(_imageBytes!, fit: BoxFit.contain),
+        ColorFiltered(
+          colorFilter: zoomPanState.displaySettings.colorFilter,
+          child: Image.memory(_imageBytes!, fit: BoxFit.contain),
+        ),
         if (annotationOverlay != null) annotationOverlay,
       ],
     );
@@ -1041,6 +1041,7 @@ class _DocumentViewerScreenState extends ConsumerState<DocumentViewerScreen>
           pageNumber: pageNumber,
           backgroundDecoration: const BoxDecoration(color: Colors.black),
           annotationOverlay: annotationOverlay,
+          colorFilter: zoomPanState.displaySettings.colorFilter,
         );
       },
     );
@@ -1066,12 +1067,14 @@ class _DocumentViewerScreenState extends ConsumerState<DocumentViewerScreen>
       annotationThickness: _activeThickness,
       onStrokeCompleted: _onStrokeCompleted,
       backgroundDecoration: const BoxDecoration(color: Colors.black),
+      colorFilter: zoomPanState.displaySettings.colorFilter,
     );
   }
 
   void _showControlsPanel() {
     showModalBottomSheet(
       context: context,
+      barrierColor: Colors.transparent,
       backgroundColor: ViewerConstants.modalBackground,
       builder: (context) => DisplaySettingsPanel(
         brightness: zoomPanState.displaySettings.brightness,

--- a/lib/screens/setlist_performance_screen.dart
+++ b/lib/screens/setlist_performance_screen.dart
@@ -357,6 +357,7 @@ class _SetListPerformanceScreenState extends State<SetListPerformanceScreen>
   void _showDisplaySettings() {
     showModalBottomSheet(
       context: context,
+      barrierColor: Colors.transparent,
       backgroundColor: ViewerConstants.modalBackground,
       builder: (context) => DisplaySettingsPanel(
         brightness: zoomPanState.displaySettings.brightness,
@@ -390,36 +391,32 @@ class _SetListPerformanceScreenState extends State<SetListPerformanceScreen>
         body: buildZoomPanGestureDetector(
           child: Stack(
             children: [
-              ColorFiltered(
-                colorFilter: zoomPanState.displaySettings.colorFilter,
-                child: buildZoomPanTransform(
-                  child: PageView.builder(
-                    controller: _documentPageController,
-                    itemCount: widget.documents.length,
-                    onPageChanged: _onDocumentChanged,
-                    physics:
-                        const NeverScrollableScrollPhysics(), // Disable swipe, use buttons only
-                    itemBuilder: (context, index) {
-                      final pdfDocument = _pdfDocuments[index];
-                      if (pdfDocument == null) {
-                        return const Center(
-                          child: CircularProgressIndicator(color: Colors.white),
-                        );
-                      }
-
-                      return PerformanceDocumentView(
-                        key: _documentViewKeys[index],
-                        document: widget.documents[index],
-                        pdfDocument: pdfDocument,
-                        viewMode: _viewMode,
-                        initialPage: _currentPages[index] ?? 1,
-                        onReachedStart: _onReachedDocumentStart,
-                        onReachedEnd: _onReachedDocumentEnd,
-                        onPageChanged: (spread) =>
-                            _onPageChanged(index, spread),
+              buildZoomPanTransform(
+                child: PageView.builder(
+                  controller: _documentPageController,
+                  itemCount: widget.documents.length,
+                  onPageChanged: _onDocumentChanged,
+                  physics: const NeverScrollableScrollPhysics(),
+                  itemBuilder: (context, index) {
+                    final pdfDocument = _pdfDocuments[index];
+                    if (pdfDocument == null) {
+                      return const Center(
+                        child: CircularProgressIndicator(color: Colors.white),
                       );
-                    },
-                  ),
+                    }
+
+                    return PerformanceDocumentView(
+                      key: _documentViewKeys[index],
+                      document: widget.documents[index],
+                      pdfDocument: pdfDocument,
+                      viewMode: _viewMode,
+                      initialPage: _currentPages[index] ?? 1,
+                      onReachedStart: _onReachedDocumentStart,
+                      onReachedEnd: _onReachedDocumentEnd,
+                      onPageChanged: (spread) => _onPageChanged(index, spread),
+                      colorFilter: zoomPanState.displaySettings.colorFilter,
+                    );
+                  },
                 ),
               ),
 

--- a/lib/widgets/cached_pdf_page.dart
+++ b/lib/widgets/cached_pdf_page.dart
@@ -15,6 +15,7 @@ class CachedPdfPage extends StatefulWidget {
     this.onPageRendered,
     this.fit = BoxFit.contain,
     this.annotationOverlay,
+    this.colorFilter,
     super.key,
   });
 
@@ -37,6 +38,9 @@ class CachedPdfPage extends StatefulWidget {
   /// When provided, both PDF and annotations are scaled together using FittedBox,
   /// ensuring consistent coordinate systems across different view modes.
   final Widget? annotationOverlay;
+
+  /// Optional color filter applied to the page content only (not the background).
+  final ColorFilter? colorFilter;
 
   @override
   State<CachedPdfPage> createState() => _CachedPdfPageState();
@@ -131,8 +135,16 @@ class _CachedPdfPageState extends State<CachedPdfPage> {
       return Text(context.l10n.failedToRenderPage);
     }
 
+    Widget image = Image.memory(
+      _pageImage!.bytes,
+      fit: widget.annotationOverlay == null ? widget.fit : BoxFit.fill,
+    );
+    if (widget.colorFilter != null) {
+      image = ColorFiltered(colorFilter: widget.colorFilter!, child: image);
+    }
+
     if (widget.annotationOverlay == null) {
-      return Image.memory(_pageImage!.bytes, fit: widget.fit);
+      return image;
     }
 
     // With annotation overlay: use FittedBox to scale PDF and annotations together
@@ -143,10 +155,7 @@ class _CachedPdfPageState extends State<CachedPdfPage> {
         height: _pageImage!.height.toDouble(),
         child: Stack(
           fit: StackFit.expand,
-          children: [
-            Image.memory(_pageImage!.bytes, fit: BoxFit.fill),
-            widget.annotationOverlay!,
-          ],
+          children: [image, widget.annotationOverlay!],
         ),
       ),
     );

--- a/lib/widgets/performance_document_view.dart
+++ b/lib/widgets/performance_document_view.dart
@@ -23,6 +23,7 @@ class PerformanceDocumentView extends StatefulWidget {
     this.onReachedStart,
     this.onReachedEnd,
     this.onPageChanged,
+    this.colorFilter,
     super.key,
   });
 
@@ -46,6 +47,9 @@ class PerformanceDocumentView extends StatefulWidget {
 
   /// Called when the current page changes, with left page and optional right page
   final ValueChanged<({int left, int? right})>? onPageChanged;
+
+  /// Optional color filter applied to page content only (not the background).
+  final ColorFilter? colorFilter;
 
   @override
   State<PerformanceDocumentView> createState() =>
@@ -323,6 +327,7 @@ class PerformanceDocumentViewState extends State<PerformanceDocumentView> {
           pageNumber: pageNumber,
           backgroundDecoration: const BoxDecoration(color: Colors.black),
           annotationOverlay: annotationOverlay,
+          colorFilter: widget.colorFilter,
         );
       },
     );
@@ -340,6 +345,7 @@ class PerformanceDocumentViewState extends State<PerformanceDocumentView> {
       isAnnotationMode: false, // Read-only
       selectedLayerId: _layers.isNotEmpty ? _layers.first.id : null,
       backgroundDecoration: const BoxDecoration(color: Colors.black),
+      colorFilter: widget.colorFilter,
     );
   }
 }

--- a/lib/widgets/two_page_pdf_view.dart
+++ b/lib/widgets/two_page_pdf_view.dart
@@ -22,6 +22,7 @@ class TwoPagePdfView extends StatelessWidget {
     this.annotationThickness = 3.0,
     this.onStrokeCompleted,
     this.backgroundDecoration,
+    this.colorFilter,
     super.key,
   });
 
@@ -61,6 +62,9 @@ class TwoPagePdfView extends StatelessWidget {
   /// Background decoration for page containers
   final BoxDecoration? backgroundDecoration;
 
+  /// Optional color filter applied to page content only (not the background).
+  final ColorFilter? colorFilter;
+
   @override
   Widget build(BuildContext context) {
     return Row(
@@ -77,6 +81,7 @@ class TwoPagePdfView extends StatelessWidget {
             annotationThickness: annotationThickness,
             onStrokeCompleted: onStrokeCompleted,
             backgroundDecoration: backgroundDecoration,
+            colorFilter: colorFilter,
           ),
         ),
         Expanded(
@@ -92,6 +97,7 @@ class TwoPagePdfView extends StatelessWidget {
                   annotationThickness: annotationThickness,
                   onStrokeCompleted: onStrokeCompleted,
                   backgroundDecoration: backgroundDecoration,
+                  colorFilter: colorFilter,
                 )
               : Container(
                   decoration:
@@ -117,6 +123,7 @@ class _PageContainer extends StatelessWidget {
     required this.annotationThickness,
     this.onStrokeCompleted,
     this.backgroundDecoration,
+    this.colorFilter,
   });
 
   final PdfDocument document;
@@ -129,6 +136,7 @@ class _PageContainer extends StatelessWidget {
   final double annotationThickness;
   final VoidCallback? onStrokeCompleted;
   final BoxDecoration? backgroundDecoration;
+  final ColorFilter? colorFilter;
 
   @override
   Widget build(BuildContext context) {
@@ -156,6 +164,7 @@ class _PageContainer extends StatelessWidget {
         pageNumber: pageNumber,
         backgroundDecoration: backgroundDecoration,
         annotationOverlay: annotationOverlay,
+        colorFilter: colorFilter,
       ),
     );
   }


### PR DESCRIPTION
## Changes

### 1. Brightness/contrast now only affects the document content, not the background.

The `ColorFiltered` widget was wrapping the entire zoom/pan transform (including black background areas). Moved the color filter down to the leaf level — it's now applied only to `Image.memory` widgets inside `CachedPdfPage` (for PDFs) and directly on the image in `_buildImageView` (for images). The filter propagates through `colorFilter` parameters on `CachedPdfPage`, `TwoPagePdfView`, and `PerformanceDocumentView`.

### 2. Contrast modal no longer dims the background.

Added `barrierColor: Colors.transparent` to the `showModalBottomSheet` in both `DocumentViewerScreen` and `SetListPerformanceScreen`.

## Files changed
- `lib/screens/document_viewer_screen.dart`
- `lib/screens/setlist_performance_screen.dart`
- `lib/widgets/cached_pdf_page.dart`
- `lib/widgets/performance_document_view.dart`
- `lib/widgets/two_page_pdf_view.dart`